### PR TITLE
Add python-setuptools to yum install command.

### DIFF
--- a/source/installguide/building_from_source.rst
+++ b/source/installguide/building_from_source.rst
@@ -348,7 +348,7 @@ Linux.
 
 .. parsed-literal::
 
-   # yum install java-1.8.0-openjdk-devel.x86_64 genisoimage mysql mysql-server ws-commons-util MySQL-python createrepo
+   # yum install java-1.8.0-openjdk-devel.x86_64 genisoimage mysql mysql-server ws-commons-util MySQL-python python-setuptools createrepo
 
 Next, you'll need to install build-time dependencies for CloudStack with
 Maven. We're using Maven 3, so you'll want to grab `Maven 3.0.5 (Binary tar.gz)


### PR DESCRIPTION
python-setuptools is necessary to build CloudStack correctly.
Without python-setuptools, you'll fail to build CloudStack with the output below:

[you@host]$ ./package.sh --pack noredist -d centos7
...
cp tools/marvin/dist/Marvin-.tar.gz "debian/tmp"/usr/share/cloudstack-marvin/
cp: cannot stat 'tools/marvin/dist/Marvin-.tar.gz': No such file or directory
...
(see also: https://github.com/wido/cloudstack-package-docker-deb/issues/1)