### PR TITLE
Fixing a dead link for cloud-set-guest-password script

### DIFF
--- a/source/adminguide/templates/_password.rst
+++ b/source/adminguide/templates/_password.rst
@@ -46,10 +46,10 @@ Linux OS Installation
 
 Use the following steps to begin the Linux OS installation:
 
-#. Download the script file cloud-set-guest-password:
+#. Download the latest version of the cloud-set-guest-password script from the repository:
 
-   -  `http://download.cloud.com/templates/4.2/bindir/cloud-set-guest-password.in 
-      <http://download.cloud.com/templates/4.2/bindir/cloud-set-guest-password.in>`_
+   -  `https://github.com/apache/cloudstack/blob/master/setup/bindir/cloud-set-guest-password.in 
+      <https://github.com/apache/cloudstack/blob/master/setup/bindir/cloud-set-guest-password.in>`_
 
 #. Rename the file:
 


### PR DESCRIPTION
cloud-set-guest-password script download link at http://docs.cloudstack.apache.org/en/4.11.1.0/adminguide/templates/_password.html#linux-os-installation is pointing towards a dead place. I replaced it with the script github page.