### PR TITLE
updated jasypt version for change db password

### DIFF
--- a/source/adminguide/management.rst
+++ b/source/adminguide/management.rst
@@ -150,7 +150,7 @@ add the encrypted password to
 
    .. code:: bash
 
-           # java -classpath /usr/share/cloudstack-common/lib/jasypt-1.9.0.jar \ org.jasypt.intf.cli.JasyptPBEStringEncryptionCLI encrypt.sh \ input="newpassword123" password="`cat /etc/cloudstack/management/key`" \ verbose=false 
+           # java -classpath /usr/share/cloudstack-common/lib/jasypt-1.9.2.jar \ org.jasypt.intf.cli.JasyptPBEStringEncryptionCLI encrypt.sh \ input="newpassword123" password="`cat /etc/cloudstack/management/key`" \ verbose=false 
 
 
 File encryption type


### PR DESCRIPTION
In later versions of CloudStack (i.e. 4.11), the jasypt .jar in
/usr/share/cloudstack-common/lib is version 1.9.2.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>