### PR TITLE
source/developersguide: removed extra http://

### DIFF
--- a/source/developersguide/dev.rst
+++ b/source/developersguide/dev.rst
@@ -136,7 +136,7 @@ To show how to sign a request, we will re-use the previous example.
 
 .. parsed-literal::
 
-   http://http://localhost:8080/client/api?command=deployVirtualMachine&serviceOfferingId=1&diskOfferingId=1&templateId=2&zoneId=4&apiKey=miVr6X7u6bN_sdahOBpjNejPgEsT35eXq-jB8CG20YI3yaxXcgpyuaIRmFI_EJTVwZ0nUkkJbPmY3y2bciKwFQ&signature=Lxx1DM40AjcXU%2FcaiK8RAP0O1hU%3D
+   http://localhost:8080/client/api?command=deployVirtualMachine&serviceOfferingId=1&diskOfferingId=1&templateId=2&zoneId=4&apiKey=miVr6X7u6bN_sdahOBpjNejPgEsT35eXq-jB8CG20YI3yaxXcgpyuaIRmFI_EJTVwZ0nUkkJbPmY3y2bciKwFQ&signature=Lxx1DM40AjcXU%2FcaiK8RAP0O1hU%3D
 
 Breaking this down, we have several distinct parts to this URL.
 


### PR DESCRIPTION
In the Signing API Requests example, there are duplicate
HTTP protocol definitions together.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>