### PR TITLE
installdocs: docs for https/ssl and TLS security configuration

### DIFF
--- a/source/installguide/optional_installation.rst
+++ b/source/installguide/optional_installation.rst
@@ -113,22 +113,6 @@ server.properties file at /etc/cloudstack/management/ location:
 For storing certificates, admins can create and configure a java keystore file
 and configure the same in the server.properties file as illustrated above.
 
-Disable Vulnerable TLS Algorithms
----------------------------------
-
-The default JRE installation used for the CloudStack management server can be
-configured to disable vulnerable TLS algorithms such as TLSv1, TLSv1.1 etc.
-To do this, you can define or override the jdk.tls.disabledAlgorithms setting
-in the JRE's java.security file typically at
-$JRE_HOME/lib/security/java.security:
-
-   .. parsed-literal::
-
-      jdk.tls.disabledAlgorithms=SSLv2Hello, SSLv3, TLSv1, TLSv1.1, DH keySize < 128, RSA keySize < 128, DES keySize < 128, SHA1 keySize < 128, MD5 keySize < 128, RC4
-
-After configuring above settings, restart the management server to disable TLS
-versions for CloudStack management server ports 8250 (agent server) and 8443
-(Jetty/HTTPS server).
 
 Database Replication (Optional)
 -------------------------------

--- a/source/installguide/optional_installation.rst
+++ b/source/installguide/optional_installation.rst
@@ -92,15 +92,43 @@ SSL (Optional)
 --------------
 
 CloudStack provides HTTP access in its default installation. There are a
-number of technologies and sites which choose to implement SSL. As a
+number of technologies and sites which choose to implement SSL/TLS. As a
 result, we have left CloudStack to expose HTTP under the assumption that
 a site will implement its typical practice.
 
-CloudStack uses Tomcat as its servlet container. For sites that would
-like CloudStack to terminate the SSL session, Tomcat’s SSL access may be
-enabled. Tomcat SSL configuration is described at
-http://tomcat.apache.org/tomcat-6.0-doc/ssl-howto.html.
+CloudStack 4.9 and above uses embedded Jetty as its servlet container. For sites
+that would like CloudStack to terminate the SSL session, HTTPS can be enabled
+by configuring the https-related settings in CloudStack management server's
+server.properties file at /etc/cloudstack/management/ location:
 
+   .. parsed-literal::
+
+      # For management server to pickup these configuration settings, the configured
+      # keystore file should exists and be readable by the management server.
+      https.enable=true
+      https.port=8443
+      https.keystore=/etc/cloudstack/management/cloud.jks
+      https.keystore.password=vmops.com
+
+For storing certificates, admins can create and configure a java keystore file
+and configure the same in the server.properties file as illustrated above.
+
+Disable Vulnerable TLS Algorithms
+---------------------------------
+
+The default JRE installation used for the CloudStack management server can be
+configured to disable vulnerable TLS algorithms such as TLSv1, TLSv1.1 etc.
+To do this, you can define or override the jdk.tls.disabledAlgorithms setting
+in the JRE's java.security file typically at
+$JRE_HOME/lib/security/java.security:
+
+   .. parsed-literal::
+
+      jdk.tls.disabledAlgorithms=SSLv2Hello, SSLv3, TLSv1, TLSv1.1, DH keySize < 128, RSA keySize < 128, DES keySize < 128, SHA1 keySize < 128, MD5 keySize < 128, RC4
+
+After configuring above settings, restart the management server to disable TLS
+versions for CloudStack management server ports 8250 (agent server) and 8443
+(Jetty/HTTPS server).
 
 Database Replication (Optional)
 -------------------------------


### PR DESCRIPTION
This fixed old tomcat ssl docs with Jetty/server.properties docs and adds section on disabling old/vulnerable TLS algorithms for JRE.