### PR TITLE
Fix the string to sign

### DIFF
--- a/source/developersguide/dev.rst
+++ b/source/developersguide/dev.rst
@@ -255,7 +255,7 @@ encoding:
 
 .. parsed-literal::
       
-   >>> sig_str='&'.join(['='.join([k.lower(),urllib.quote_plus(request[k].lower().replace('+','%20'))])for k in sorted(request.iterkeys())]) 
+   >>> sig_str='&'.join(['='.join([k.lower(),urllib.quote_plus(request[k]).lower().replace('+','%20')])for k in sorted(request.iterkeys())]) 
    >>> sig_str 'apikey=plgwjfzk4gys3momtvmjuvg-x-jlwlnfauj9gabbbf9edm-kaymmailqzzq1elzlyq_u38zcm0bewzgudp66mg&command=listusers&response=json'
    >>> sig=hmac.new(secretkey,sig_str,hashlib.sha1)
    >>> sig


### PR DESCRIPTION
The CloudStack management server signs lower-cased users' requests.
urllib.quote_plus() encodes characters into upper case hex string, so we need to call lower() at last.
