### PR TITLE
Suggest using chrony as NTP daemon

### DIFF
--- a/source/installguide/management-server/_prerequisite.rst
+++ b/source/installguide/management-server/_prerequisite.rst
@@ -77,18 +77,17 @@ node.
 #. Turn on NTP for time synchronization.
 
    .. note::
-      NTP is required to synchronize the clocks of the servers in your cloud.
+      An NTP daemon is required to synchronize the clocks of the servers in your cloud.
 
-   Install NTP.
-
-   .. parsed-literal::
-
-      yum install ntp
+   Install chrony.
 
    .. parsed-literal::
 
-      sudo apt-get install openntpd
+      yum install chrony
+
+   .. parsed-literal::
+
+      sudo apt install chrony
 
 #. Repeat all of these steps on every host where the Management Server
    will be installed.
-


### PR DESCRIPTION
RedHat strongly suggests [0] using chrony instead of ntpd and switched the
default:

17.1.2. Choosing Between NTP Daemons
Chrony should be preferred for all systems except for the systems that are
managed or monitored by tools that do not support chrony, or the systems that
have a hardware reference clock which cannot be used with chrony.

Feature comparison: [1] and [2].

It's available on RedHat/CentOS as well as Debian/Ubuntu distributions.

[0] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite
[1] https://chrony.tuxfamily.org/comparison.html
[2] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite#sect-differences_between_ntpd_and_chronyd