### PR TITLE
Update kvm.rst - setting guest.cpu options

### DIFF
--- a/source/installguide/hypervisor/kvm.rst
+++ b/source/installguide/hypervisor/kvm.rst
@@ -242,7 +242,9 @@ Here are some examples:
    host-passthrough may lead to migration failure,if you have this problem,
    you should use host-model or custom. guest.cpu.features will force cpu features
    as a required policy so make sure to put only those features that are provided
-   by the host CPU.
+   by the host CPU. As your kvm cluster needs to be made up of homogenous nodes anyway
+   (see System Requirements), it might make most sense to use guest.cpu.mode=host-model
+   or guest.cpu.mode=host-passthrough.
 
 Install and Configure libvirt
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The System Requirements for cloudstack kvm hosts mentions that all CPUs of a cluster need to be homogenous.

Either this isn't really true and can be mitigated by setting guest.cpu.mode=custom and only cpu features common to all machines
or that setting makes no real sense (causing lowest performance for no gain).