### PR TITLE
new systeVM template is required for even 4.11.3

### DIFF
--- a/source/upgrading/upgrade/upgrade-4.11.rst
+++ b/source/upgrading/upgrade/upgrade-4.11.rst
@@ -53,6 +53,10 @@ Overview of Upgrade Steps:
     If you are not already using the |sysvm64-version| System VM template you will need to 
     upgrade your System VM template prior to performing the upgrade of the 
     CloudStack packages.
+    
+.. warning::
+    Even if you are currently running CloudStack 4.11.3, you will need to explicitely register the 
+    |sysvm64-version| System VM template.
 
 .. include:: _sysvm_templates.rst
 

--- a/source/upgrading/upgrade/upgrade-4.11.rst
+++ b/source/upgrading/upgrade/upgrade-4.11.rst
@@ -55,9 +55,9 @@ Overview of Upgrade Steps:
     CloudStack packages.
     
 .. warning::
-    Even if you are currently running a *clean* CloudStack 4.11.3, you will need to explicitely register the 
-    |sysvm64-version| System VM template. If you are running 4.11.3 which was upgraded from some of the previous versions,
-    you don't need to register a new |sysvm64-version| template.
+    Even if you are currently running a **clean** install of CloudStack 4.11.3, you will need to explicitely register the 
+    |sysvm64-version| System VM template. If you are running CloudStack 4.11.3 that was upgraded from some of the previous versions,
+    you don't need to register a new |sysvm64-version| System VM template.
 
 .. include:: _sysvm_templates.rst
 

--- a/source/upgrading/upgrade/upgrade-4.11.rst
+++ b/source/upgrading/upgrade/upgrade-4.11.rst
@@ -55,8 +55,9 @@ Overview of Upgrade Steps:
     CloudStack packages.
     
 .. warning::
-    Even if you are currently running CloudStack 4.11.3, you will need to explicitely register the 
-    |sysvm64-version| System VM template.
+    Even if you are currently running a *clean* CloudStack 4.11.3, you will need to explicitely register the 
+    |sysvm64-version| System VM template. If you are running 4.11.3 which was upgraded from some of the previous versions,
+    you don't need to register a new |sysvm64-version| template.
 
 .. include:: _sysvm_templates.rst
 


### PR DESCRIPTION
clean 4.11.3 env will fail to be upgraded if "systemvm-hypervisor-4.11.3" is not explicitly registered.