### PR TITLE
remove mysql-python-connector requirements

### DIFF
--- a/source/quickinstallationguide/qig.rst
+++ b/source/quickinstallationguide/qig.rst
@@ -277,7 +277,7 @@ We need to configure the machine to use a CloudStack package repository.
    to take the source release and generate RPMs and and yum repository. This 
    guide attempts to keep things as simple as possible, and thus we are using 
    one of the community-provided yum repositories. Furthermore, this example 
-   assumes a 4.11 Cloudstack install - substitute versions as needed.
+   assumes a 4.13 Cloudstack install - substitute versions as needed.
 
 To add the CloudStack repository, create /etc/yum.repos.d/cloudstack.repo and 
 insert the following information.
@@ -286,7 +286,7 @@ insert the following information.
 
    [cloudstack]
    name=cloudstack
-   baseurl=http://download.cloudstack.org/centos/7/4.11/
+   baseurl=http://download.cloudstack.org/centos/7/4.13/
    enabled=1
    gpgcheck=0
 
@@ -467,7 +467,7 @@ the system VMs images.
   
    /usr/share/cloudstack-common/scripts/storage/secondary/cloud-install-sys-tmplt \
    -m /export/secondary \
-   -u http://download.cloudstack.org/systemvm/4.11/systemvmtemplate-4.11.2-kvm.qcow2.bz2 \
+   -u http://download.cloudstack.org/systemvm/4.11/systemvmtemplate-4.11.3-kvm.qcow2.bz2 \
    -h kvm -F
 
 

--- a/source/quickinstallationguide/qig.rst
+++ b/source/quickinstallationguide/qig.rst
@@ -421,33 +421,6 @@ start on boot as follows:
    # systemctl start mysqld
 
 
-MySQL connector Installation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Install Python MySQL connector using the official MySQL packages repository.
-Create the file ``/etc/yum.repos.d/mysql.repo`` with the following content:
-
-.. parsed-literal::
-
-   [mysql-connectors-community]
-   name=MySQL Community connectors
-   baseurl=http://repo.mysql.com/yum/mysql-connectors-community/el/$releasever/$basearch/
-   enabled=1
-   gpgcheck=1
-
-Import GPG public key from MySQL:
-
-.. parsed-literal::
-
-   rpm --import http://repo.mysql.com/RPM-GPG-KEY-mysql
-
-Install mysql-connector
-
-.. parsed-literal::
-
-   yum install mysql-connector-python
-
-
 Installation
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
afaik, It's needed only to build packages, QiG assumes packages taken from public repo