### PR TITLE
Add Bionic on supported deb packages list

### DIFF
--- a/source/installguide/management-server/_pkg_repo.rst
+++ b/source/installguide/management-server/_pkg_repo.rst
@@ -66,8 +66,7 @@ DEB package repository
 
 You can add a DEB package repository to your apt sources with the
 following commands. Please note that only packages for Ubuntu 16.04 (Xenial) 
-and Ubuntu 18.04 (Bionic) are being built at this time. 
-DISCLAIMER: Ubuntu 14.04 (Trusty) is no longer supported.
+and Ubuntu 18.04 (Bionic) are being built at this time. Ubuntu 14.04 (Trusty) is no longer supported.
 
 Use your preferred editor and open (or create)
 ``/etc/apt/sources.list.d/cloudstack.list``. Add the community provided

--- a/source/installguide/management-server/_pkg_repo.rst
+++ b/source/installguide/management-server/_pkg_repo.rst
@@ -66,7 +66,7 @@ DEB package repository
 
 You can add a DEB package repository to your apt sources with the
 following commands. Please note that only packages for Ubuntu 14.04 LTS
-(Trusty) and Ubuntu 16.04 (Xenial) are being built at this time. DISCLAIMER: Ubuntu 12.04 (Precise) is no longer supported.
+(Trusty), Ubuntu 16.04 (Xenial) and Ubuntu 18.04 (Bionic) are being built at this time. DISCLAIMER: Ubuntu 12.04 (Precise) is no longer supported.
 
 Use your preferred editor and open (or create)
 ``/etc/apt/sources.list.d/cloudstack.list``. Add the community provided

--- a/source/installguide/management-server/_pkg_repo.rst
+++ b/source/installguide/management-server/_pkg_repo.rst
@@ -65,8 +65,9 @@ DEB package repository
 ~~~~~~~~~~~~~~~~~~~~~~
 
 You can add a DEB package repository to your apt sources with the
-following commands. Please note that only packages for Ubuntu 14.04 LTS
-(Trusty), Ubuntu 16.04 (Xenial) and Ubuntu 18.04 (Bionic) are being built at this time. DISCLAIMER: Ubuntu 12.04 (Precise) is no longer supported.
+following commands. Please note that only packages for Ubuntu 16.04 (Xenial) 
+and Ubuntu 18.04 (Bionic) are being built at this time. 
+DISCLAIMER: Ubuntu 14.04 (Trusty) is no longer supported.
 
 Use your preferred editor and open (or create)
 ``/etc/apt/sources.list.d/cloudstack.list``. Add the community provided


### PR DESCRIPTION
Since CloudStack 4.12 we are supporting deb packages for Ubuntu 18.04 (Bionic). However, the [deb-package-repository](http://docs.cloudstack.apache.org/en/latest/installguide/management-server/index.html#deb-package-repository) documentation lists support for 14.04 and 16.04 only. 

Therefore, this PR adds packages support for Ubuntu 18.04 (Bionic) on documentation.