### PR TITLE
remove-environment.properties-note

### DIFF
--- a/source/upgrading/upgrade/upgrade-4.11.rst
+++ b/source/upgrading/upgrade/upgrade-4.11.rst
@@ -303,15 +303,6 @@ hosts.
 
       $ sudo apt-get upgrade cloudstack-agent
 
-#. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a
-    line that reads:
-
-   .. parsed-literal::
-
-      paths.script=/usr/share/cloudstack-common
-
-   If not, add the line.
-
 #. Start the agent.
 
    .. parsed-literal::
@@ -329,15 +320,6 @@ For KVM hosts, upgrade the ``cloudstack-agent`` package
    .. parsed-literal::
 
       $ sudo yum upgrade cloudstack-agent
-
-#. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a
-   line that reads:
-
-   .. parsed-literal::
-
-      paths.script=/usr/share/cloudstack-common
-
-   If not, add the line.
 
 #. Restart the agent:
 

--- a/source/upgrading/upgrade/upgrade-4.12.rst
+++ b/source/upgrading/upgrade/upgrade-4.12.rst
@@ -299,15 +299,6 @@ hosts.
 
       $ sudo apt-get upgrade cloudstack-agent
 
-#. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a
-   line that reads:
-
-   .. parsed-literal::
-
-      paths.script=/usr/share/cloudstack-common
-
-   If not, add the line.
-
 #. Start the agent.
 
    .. parsed-literal::
@@ -325,15 +316,6 @@ For KVM hosts, upgrade the ``cloudstack-agent`` package
    .. parsed-literal::
 
       $ sudo yum upgrade cloudstack-agent
-
-#. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a
-   line that reads:
-
-   .. parsed-literal::
-
-      paths.script=/usr/share/cloudstack-common
-
-   If not, add the line.
 
 #. Restart the agent:
 

--- a/source/upgrading/upgrade/upgrade-4.13.rst
+++ b/source/upgrading/upgrade/upgrade-4.13.rst
@@ -268,15 +268,6 @@ hosts.
 
       $ sudo apt-get upgrade cloudstack-agent
 
-#. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a
-   line that reads:
-
-   .. parsed-literal::
-
-      paths.script=/usr/share/cloudstack-common
-
-   If not, add the line.
-
 #. Start the agent.
 
    .. parsed-literal::
@@ -294,15 +285,6 @@ For KVM hosts, upgrade the ``cloudstack-agent`` package
    .. parsed-literal::
 
       $ sudo yum upgrade cloudstack-agent
-
-#. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a
-   line that reads:
-
-   .. parsed-literal::
-
-      paths.script=/usr/share/cloudstack-common
-
-   If not, add the line.
 
 #. Restart the agent:
 


### PR DESCRIPTION
The starting premise  "if it doesn't exist" is impossible in the first place... (tested on 4.11.0 - agent will never connect if that line is missing in the file) - then no need to the warning/message - so removing it from 4.11+ Upgrade pages.