### PR TITLE
update qig.rst

### DIFF
--- a/source/quickinstallationguide/qig.rst
+++ b/source/quickinstallationguide/qig.rst
@@ -494,7 +494,7 @@ the system VMs images.
   
    /usr/share/cloudstack-common/scripts/storage/secondary/cloud-install-sys-tmplt \
    -m /export/secondary \
-   -u http://download.cloudstack.org/systemvm/4.11/systemvmtemplate-4.11.2-kvm.qcow2.bz2 \
+   -u http://download.cloudstack.org/systemvm/4.11/systemvmtemplate-4.11.3-kvm.qcow2.bz2 \
    -h kvm -F
 
 


### PR DESCRIPTION
The current systemvm template version `4.11.2` in the quick installation guide is not correct, which will make the system VMs not up according to [this issue](https://github.com/apache/cloudstack/issues/4072#issuecomment-627139142). It should be updated to `4.11.3`. 