### PR TITLE
Renamed dhclient folder to DHCP

### DIFF
--- a/source/adminguide/accounts.rst
+++ b/source/adminguide/accounts.rst
@@ -47,6 +47,7 @@ For each account created, the Cloud installation creates three different
 types of user accounts: root administrator, domain administrator, and
 user.
 
+
 Users
 ~~~~~
 

--- a/source/adminguide/accounts.rst
+++ b/source/adminguide/accounts.rst
@@ -43,9 +43,8 @@ delegated administrators with some authority over the domain and its
 subdomains. For example, a service provider with several resellers could
 create a domain for each reseller.
 
-For each domain created, the Cloud installation creates three different
-types of user accounts: root administrator, domain administrator, and
-user.
+Beside the Root Administrator type of account (available in the root domain only), two different types
+of accounts can be created for each domain:  Domain Administrator and User.
 
 
 Users

--- a/source/adminguide/accounts.rst
+++ b/source/adminguide/accounts.rst
@@ -43,7 +43,7 @@ delegated administrators with some authority over the domain and its
 subdomains. For example, a service provider with several resellers could
 create a domain for each reseller.
 
-For each account created, the Cloud installation creates three different
+For each domain created, the Cloud installation creates three different
 types of user accounts: root administrator, domain administrator, and
 user.
 

--- a/source/adminguide/accounts.rst
+++ b/source/adminguide/accounts.rst
@@ -43,9 +43,9 @@ delegated administrators with some authority over the domain and its
 subdomains. For example, a service provider with several resellers could
 create a domain for each reseller.
 
-Beside the Root Administrator type of account (available in the root domain only), two different types
-of accounts can be created for each domain:  Domain Administrator and User.
-
+For each account created, the Cloud installation creates three different
+types of user accounts: root administrator, domain administrator, and
+user.
 
 Users
 ~~~~~

--- a/source/adminguide/virtual_machines/user-data.rst
+++ b/source/adminguide/virtual_machines/user-data.rst
@@ -33,7 +33,7 @@ known, use the following steps to retrieve user-data:
 
    .. code:: bash
 
-      # cat /var/lib/dhclient/dhclient-eth0.leases | grep dhcp-server-identifier | tail -1
+      # cat /var/lib/dhcp/dhclient-eth0.leases | grep dhcp-server-identifier | tail -1
 
 #. Access user-data by running the following command using the result of
    the above command

--- a/source/adminguide/virtual_machines/user-data.rst
+++ b/source/adminguide/virtual_machines/user-data.rst
@@ -33,7 +33,7 @@ known, use the following steps to retrieve user-data:
 
    .. code:: bash
 
-      # cat /var/lib/dhcp/dhclient-eth0.leases | grep dhcp-server-identifier | tail -1
+      # cat /var/lib/dhcp/dhclient.eth0.leases | grep dhcp-server-identifier | tail -1
 
 #. Access user-data by running the following command using the result of
    the above command


### PR DESCRIPTION
Correct file path for `dhclient-eth0.leases` is `/var/lib/dhcp/dhclient.eth0.leases`

```bash
root@host# find / -name dhclient-eth0.leases
/var/lib/dhcp/dhclient.eth0.leases
```