### PR TITLE
releasenotes: add note about CentOS 8 EOL in Dec 2021

### DIFF
--- a/source/releasenotes/about.rst
+++ b/source/releasenotes/about.rst
@@ -21,7 +21,7 @@ Apache CloudStack |release| is a |version| LTS release with over FIXME major new
 features, and over 100 enhancements and fixes since 4.14.  Highlights include:
 
 • New modern UI (GA release)
-• Support for CentOS8 and Ubuntu 20.04 as management server hosts and KVM hosts
+• Support for CentOS8 and Ubuntu 20.04 as management server hosts and KVM hosts (note: CentOS 8 will EOL in Dec 2021)
 • FIXME: add rest of new features
 
 The full list of new features can be found in the project release notes at
@@ -62,7 +62,9 @@ workaround in their KVM host's /etc/ssh/sshd_config and restart ssh server
 before adding the KVM host in CloudStack:
 
    PubkeyAcceptedKeyTypes=+ssh-dss
+
    HostKeyAlgorithms=+ssh-dss
+
    KexAlgorithms=+diffie-hellman-group1-sha1
 
 New UI GA and Legacy UI Deprecation and Removal Notice

--- a/source/releasenotes/compat.rst
+++ b/source/releasenotes/compat.rst
@@ -22,8 +22,8 @@ Supported OS Versions for Management Server
 This section lists the operating systems that are supported for running
 CloudStack Management Server.
 
--  Ubuntu 16.04 LTS, 18.04, 20.04 LTS
--  CentOS versions 7.x, 8.x
+-  Ubuntu 16.04 LTS, 18.04 LTS, 20.04 LTS
+-  CentOS versions 7.x, 8.x (note: CentOS 8 will EOL in Dec 2021)
 -  RHEL versions 7.x, 8.x
 
 Software Requirements
@@ -39,7 +39,7 @@ CloudStack supports three hypervisor families, XenServer with XAPI, KVM,
 and VMware with vSphere.
 
 -  Ubuntu 16.04 LTS, 18.04, 20.04 LTS with KVM
--  CentOS 7.x, 8.x with KVM
+-  CentOS 7.x, 8.x with KVM (note: CentOS 8 will EOL in Dec 2021)
 -  Red Hat Enterprise Linux 7.x, 8.x with KVM
 -  XenServer versions 7.0, 7.1, 7.2, 7.4, 7.5, 8.0 with latest hotfixes, XCP-ng 7.4, 7.6, 8.0, 8.1
 


### PR DESCRIPTION
This adds notes in release notes's compatibilty matrix page and about page.