### PR TITLE
vm: fix display name, internal name notes

### DIFF
--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -322,8 +322,8 @@ To access a VM through the CloudStack UI:
 #. Click Apply.
 
 
-Appending a Display Name to the Guest VM’s Internal Name
-----------------------------------------------------------
+Appending a Name to the Guest VM’s Internal Name
+------------------------------------------------
 
 Every guest VM has an internal name. The host uses the internal name to identify the guest VMs. CloudStack gives you an option to provide a guest VM with a  name. You can set this name as the internal name so that the vCenter can use it to identify the guest VM. A new global parameter, vm.instancename.flag, has now been added to achieve this functionality.
 
@@ -333,14 +333,14 @@ The following table explains how a VM name is displayed in different scenarios.
 
 .. cssclass:: table-striped table-bordered table-hover
 
-============================= ======================= ====================== ====================== ====================== ===================================== ==========================
-User-Provided Display Name    vm.instancename.flag    User                   Display Name           Hostname on the VM     Name on vCenter                       Internal Name
-============================= ======================= ====================== ====================== ====================== ===================================== ==========================
-Yes                           True                    <Name>                 <Display name>         <Name>                 i-<user\_id>-<vm\_id>-<Name>          i-<user\_id>-<vm\_id>-<Name>
-No                            True                    <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> i-<user\_id>-<vm\_id>-<instance.name> <instance.name>-<UUID>
-Yes                           False                   <Name>                 <Display name>         <Name>                 i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
-No                            False                   <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
-============================= ======================= ====================== ====================== ====================== ===================================== ==========================
+===================== ======================= ====================== ====================== ====================== ===================================== ==========================
+User-Provided Name    vm.instancename.flag    User                   Display Name           Hostname on the VM     Name on vCenter                       Internal Name
+===================== ======================= ====================== ====================== ====================== ===================================== ==========================
+Yes                   True                    <Name>                 <Display name>         <Name>                 i-<user\_id>-<vm\_id>-<Name>          i-<user\_id>-<vm\_id>-<Name>
+No                    True                    <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> i-<user\_id>-<vm\_id>-<instance.name> <instance.name>-<UUID>
+Yes                   False                   <Name>                 <Display name>         <Name>                 i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
+No                    False                   <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
+===================== ======================= ====================== ====================== ====================== ===================================== ==========================
 
 
 Changing the Service Offering for a VM

--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -327,21 +327,21 @@ Appending a Name to the Guest VM’s Internal Name
 
 Every guest VM has an internal name. The host uses the internal name to identify the guest VMs. CloudStack gives you an option to provide a guest VM with a  name. You can set this name as the internal name so that the vCenter can use it to identify the guest VM. A new global parameter, vm.instancename.flag, has now been added to achieve this functionality.
 
-The default format of the internal name is i-<user\_id>-<vm\_id>-<i.n>, where i.n is the value of the global configuration - instance.name. However, If vm.instancename.flag is set to true, and if a name is provided during the creation of a guest VM, the name is appended to the internal name of the guest VM on the host. This makes the internal name format as i-<user\_id>-<vm\_id>-<name>. The default value of vm.instancename.flag is set to false. This feature is intended to make the correlation between instance names and internal names easier in large data center deployments.
+The default format of the internal name is i-<account\_id>-<vm\_id>-<i.n>, where i.n is the value of the global configuration - instance.name. However, If vm.instancename.flag is set to true, and if a name is provided during the creation of a guest VM, the name is appended to the internal name of the guest VM on the host. This makes the internal name format as i-<account\_id>-<vm\_id>-<name>. The default value of vm.instancename.flag is set to false. This feature is intended to make the correlation between instance names and internal names easier in large data center deployments.
 
 The following table explains how a VM name is displayed in different scenarios.
 
 .. cssclass:: table-striped table-bordered table-hover
 
-======================== ============================ =========================== =========================== ===========================
-**User-Provided Name**   Yes                          No                          Yes                         No
-**vm.instancename.flag** True                         True                        False                       False
-**Name**                 <Name>                       <i.n>-<UUID>                <Name>                      <i.n>-<UUID>
-**Display Name**         <Display name>               <i.n>-<UUID>                <Display name>              <i.n>-<UUID>
-**Hostname on the VM**   <Name>                       <i.n>-<UUID>                <Name>                      <i.n>-<UUID>
-**Name on vCenter**      i-<user\_id>-<vm\_id>-<Name> <i.n>-<UUID>                i-<user\_id>-<vm\_id>-<i.n> i-<user\_id>-<vm\_id>-<i.n>
-**Internal Name**        i-<user\_id>-<vm\_id>-<Name> i-<user\_id>-<vm\_id>-<i.n> i-<user\_id>-<vm\_id>-<i.n> i-<user\_id>-<vm\_id>-<i.n>
-======================== ============================ =========================== =========================== ===========================
+======================== =============================== ============================== ============================== ===========================
+**User-Provided Name**   Yes                             No                             Yes                            No
+**vm.instancename.flag** True                            True                           False                          False
+**Name**                 <Name>                          <i.n>-<UUID>                   <Name>                         <i.n>-<UUID>
+**Display Name**         <Display name>                  <i.n>-<UUID>                   <Display name>                 <i.n>-<UUID>
+**Hostname on the VM**   <Name>                          <i.n>-<UUID>                   <Name>                         <i.n>-<UUID>
+**Name on vCenter**      i-<account\_id>-<vm\_id>-<Name> <i.n>-<UUID>                   i-<account\_id>-<vm\_id>-<i.n> i-<account\_id>-<vm\_id>-<i.n>
+**Internal Name**        i-<account\_id>-<vm\_id>-<Name> i-<account\_id>-<vm\_id>-<i.n> i-<account\_id>-<vm\_id>-<i.n> i-<account\_id>-<vm\_id>-<i.n>
+======================== =============================== ============================== ============================== ===========================
 
    .. note::
       <i.n> represents the value of the global configuration - instance.name

--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -38,8 +38,8 @@ names can be controlled by the user:
 
 .. note:: 
    You can append the display name of a guest VM to its internal name. 
-   For more information, see `“Appending a Display Name to the Guest VM’s 
-   Internal Name” <#appending-a-display-name-to-the-guest-vms-internal-name>`_.
+   For more information, see `“Appending a Name to the Guest VM’s
+   Internal Name” <#appending-a-name-to-the-guest-vms-internal-name>`_.
 
 Guest VMs can be configured to be Highly Available (HA). An HA-enabled
 VM is monitored by the system. If the system detects that the VM is
@@ -342,15 +342,6 @@ The following table explains how a VM name is displayed in different scenarios.
 **Name on vCenter**      i-<user\_id>-<vm\_id>-<Name> <i.n>-<UUID>                i-<user\_id>-<vm\_id>-<i.n> i-<user\_id>-<vm\_id>-<i.n>
 **Internal Name**        i-<user\_id>-<vm\_id>-<Name> i-<user\_id>-<vm\_id>-<i.n> i-<user\_id>-<vm\_id>-<i.n> i-<user\_id>-<vm\_id>-<i.n>
 ======================== ============================ =========================== =========================== ===========================
-
-================== ==================== ============ ============== ================== ============================ ============================
-User-Provided Name vm.instancename.flag Name         Display Name   Hostname on the VM Name on vCenter              Internal Name
-================== ==================== ============ ============== ================== ============================ ============================
-Yes                True                 <Name>       <Display name> <Name>             i-<user\_id>-<vm\_id>-<Name> i-<user\_id>-<vm\_id>-<Name>
-No                 True                 <i.n>-<UUID> <i.n>-<UUID>   <i.n>-<UUID>       <i.n>-<UUID>                 i-<user\_id>-<vm\_id>-<i.n>
-Yes                False                <Name>       <Display name> <Name>             i-<user\_id>-<vm\_id>-<i.n>  i-<user\_id>-<vm\_id>-<i.n>
-No                 False                <i.n>-<UUID> <i.n>-<UUID>   <i.n>-<UUID>       i-<user\_id>-<vm\_id>-<i.n>  i-<user\_id>-<vm\_id>-<i.n>
-================== ==================== ============ ============== ================== ============================ ============================
 
    .. note::
       <i.n> represents the value of global configuration - instance.name

--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -337,7 +337,7 @@ The following table explains how a VM name is displayed in different scenarios.
 User-Provided Name    vm.instancename.flag    User                   Display Name           Hostname on the VM     Name on vCenter                       Internal Name
 ===================== ======================= ====================== ====================== ====================== ===================================== ==========================
 Yes                   True                    <Name>                 <Display name>         <Name>                 i-<user\_id>-<vm\_id>-<Name>          i-<user\_id>-<vm\_id>-<Name>
-No                    True                    <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> i-<user\_id>-<vm\_id>-<instance.name> <instance.name>-<UUID>
+No                    True                    <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID>                i-<user\_id>-<vm\_id>-<instance.name>
 Yes                   False                   <Name>                 <Display name>         <Name>                 i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
 No                    False                   <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
 ===================== ======================= ====================== ====================== ====================== ===================================== ==========================

--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -322,7 +322,7 @@ To access a VM through the CloudStack UI:
 #. Click Apply.
 
 
-Appending VM Name to the Guest VM’s Internal Name
+Appending a Display Name to the Guest VM’s Internal Name
 ----------------------------------------------------------
 
 Every guest VM has an internal name. The host uses the internal name to identify the guest VMs. CloudStack gives you an option to provide a guest VM with a  name. You can set this name as the internal name so that the vCenter can use it to identify the guest VM. A new global parameter, vm.instancename.flag, has now been added to achieve this functionality.

--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -323,11 +323,11 @@ To access a VM through the CloudStack UI:
 
 
 Appending a Name to the Guest VM’s Internal Name
-------------------------------------------------
+--------------------------------------------------
 
 Every guest VM has an internal name. The host uses the internal name to identify the guest VMs. CloudStack gives you an option to provide a guest VM with a  name. You can set this name as the internal name so that the vCenter can use it to identify the guest VM. A new global parameter, vm.instancename.flag, has now been added to achieve this functionality.
 
-The default format of the internal name is i-<user\_id>-<vm\_id>-<i.n>, where i.n is the value global configuration - instance.name. However, If vm.instancename.flag is set to true, and if a name is provided during the creation of a guest VM, the name is appended to the internal name of the guest VM on the host. This makes the internal name format as i-<user\_id>-<vm\_id>-<name>. The default value of vm.instancename.flag is set to false. This feature is intended to make the correlation between instance names and internal names easier in large data center deployments.
+The default format of the internal name is i-<user\_id>-<vm\_id>-<i.n>, where i.n is the value of the global configuration - instance.name. However, If vm.instancename.flag is set to true, and if a name is provided during the creation of a guest VM, the name is appended to the internal name of the guest VM on the host. This makes the internal name format as i-<user\_id>-<vm\_id>-<name>. The default value of vm.instancename.flag is set to false. This feature is intended to make the correlation between instance names and internal names easier in large data center deployments.
 
 The following table explains how a VM name is displayed in different scenarios.
 

--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -344,7 +344,7 @@ The following table explains how a VM name is displayed in different scenarios.
 ======================== ============================ =========================== =========================== ===========================
 
 ================== ==================== ============ ============== ================== ============================ ============================
-User-Provided Name vm.instancename.flag User         Display Name   Hostname on the VM Name on vCenter              Internal Name
+User-Provided Name vm.instancename.flag Name         Display Name   Hostname on the VM Name on vCenter              Internal Name
 ================== ==================== ============ ============== ================== ============================ ============================
 Yes                True                 <Name>       <Display name> <Name>             i-<user\_id>-<vm\_id>-<Name> i-<user\_id>-<vm\_id>-<Name>
 No                 True                 <i.n>-<UUID> <i.n>-<UUID>   <i.n>-<UUID>       <i.n>-<UUID>                 i-<user\_id>-<vm\_id>-<i.n>

--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -38,7 +38,7 @@ names can be controlled by the user:
 
 .. note:: 
    You can append the display name of a guest VM to its internal name. 
-   For more information, see `“Appending a Name to the Guest VM’s
+   For more information, see `“Appending a Name to the Guest VM’s 
    Internal Name” <#appending-a-name-to-the-guest-vms-internal-name>`_.
 
 Guest VMs can be configured to be Highly Available (HA). An HA-enabled
@@ -344,7 +344,7 @@ The following table explains how a VM name is displayed in different scenarios.
 ======================== ============================ =========================== =========================== ===========================
 
    .. note::
-      <i.n> represents the value of global configuration - instance.name
+      <i.n> represents the value of the global configuration - instance.name
 
 
 Changing the Service Offering for a VM

--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -347,14 +347,14 @@ scenarios.
 
 .. cssclass:: table-striped table-bordered table-hover
 
-============================= ======================= ==================== ===================================== ==========================
-User-Provided Display Name    vm.instancename.flag    Hostname on the VM   Name on vCenter                       Internal Name
-============================= ======================= ==================== ===================================== ==========================
-Yes                           True                    Display name         i-<user\_id>-<vm\_id>-displayName     i-<user\_id>-<vm\_id>-displayName
-No                            True                    UUID                 i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
-Yes                           False                   Display name         i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
-No                            False                   UUID                 i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
-============================= ======================= ==================== ===================================== ==========================
+============================= ======================= ====================== ====================== ====================== ===================================== ==========================
+User-Provided Display Name    vm.instancename.flag    User                   Display Name           Hostname on the VM     Name on vCenter                       Internal Name
+============================= ======================= ====================== ====================== ====================== ===================================== ==========================
+Yes                           True                    Name                   Display name           Name                   i-<user\_id>-<vm\_id>-name            i-<user\_id>-<vm\_id>-name
+No                            True                    <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> i-<user\_id>-<vm\_id>-<instance.name> <instance.name>-<UUID>
+Yes                           False                   Name                   Display name           Name                   i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
+No                            False                   <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
+============================= ======================= ====================== ====================== ====================== ===================================== ==========================
 
 
 Changing the Service Offering for a VM

--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -336,9 +336,9 @@ The following table explains how a VM name is displayed in different scenarios.
 ============================= ======================= ====================== ====================== ====================== ===================================== ==========================
 User-Provided Display Name    vm.instancename.flag    User                   Display Name           Hostname on the VM     Name on vCenter                       Internal Name
 ============================= ======================= ====================== ====================== ====================== ===================================== ==========================
-Yes                           True                    Name                   Display name           Name                   i-<user\_id>-<vm\_id>-name            i-<user\_id>-<vm\_id>-name
+Yes                           True                    <Name>                 <Display name>         <Name>                 i-<user\_id>-<vm\_id>-<Name>          i-<user\_id>-<vm\_id>-<Name>
 No                            True                    <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> i-<user\_id>-<vm\_id>-<instance.name> <instance.name>-<UUID>
-Yes                           False                   Name                   Display name           Name                   i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
+Yes                           False                   <Name>                 <Display name>         <Name>                 i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
 No                            False                   <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
 ============================= ======================= ====================== ====================== ====================== ===================================== ==========================
 

--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -327,20 +327,33 @@ Appending a Name to the Guest VM’s Internal Name
 
 Every guest VM has an internal name. The host uses the internal name to identify the guest VMs. CloudStack gives you an option to provide a guest VM with a  name. You can set this name as the internal name so that the vCenter can use it to identify the guest VM. A new global parameter, vm.instancename.flag, has now been added to achieve this functionality.
 
-The default format of the internal name is i-<user\_id>-<vm\_id>-<instance.name>, where instance.name is a global parameter. However, If vm.instancename.flag is set to true, and if a name is provided during the creation of a guest VM, the name is appended to the internal name of the guest VM on the host. This makes the internal name format as i-<user\_id>-<vm\_id>-<name>. The default value of vm.instancename.flag is set to false. This feature is intended to make the correlation between instance names and internal names easier in large data center deployments.
+The default format of the internal name is i-<user\_id>-<vm\_id>-<i.n>, where i.n is the value global configuration - instance.name. However, If vm.instancename.flag is set to true, and if a name is provided during the creation of a guest VM, the name is appended to the internal name of the guest VM on the host. This makes the internal name format as i-<user\_id>-<vm\_id>-<name>. The default value of vm.instancename.flag is set to false. This feature is intended to make the correlation between instance names and internal names easier in large data center deployments.
 
 The following table explains how a VM name is displayed in different scenarios.
 
 .. cssclass:: table-striped table-bordered table-hover
 
-===================== ======================= ====================== ====================== ====================== ===================================== ==========================
-User-Provided Name    vm.instancename.flag    User                   Display Name           Hostname on the VM     Name on vCenter                       Internal Name
-===================== ======================= ====================== ====================== ====================== ===================================== ==========================
-Yes                   True                    <Name>                 <Display name>         <Name>                 i-<user\_id>-<vm\_id>-<Name>          i-<user\_id>-<vm\_id>-<Name>
-No                    True                    <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID>                i-<user\_id>-<vm\_id>-<instance.name>
-Yes                   False                   <Name>                 <Display name>         <Name>                 i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
-No                    False                   <instance.name>-<UUID> <instance.name>-<UUID> <instance.name>-<UUID> i-<user\_id>-<vm\_id>-<instance.name> i-<user\_id>-<vm\_id>-<instance.name>
-===================== ======================= ====================== ====================== ====================== ===================================== ==========================
+======================== ============================ =========================== =========================== ===========================
+**User-Provided Name**   Yes                          No                          Yes                         No
+**vm.instancename.flag** True                         True                        False                       False
+**Name**                 <Name>                       <i.n>-<UUID>                <Name>                      <i.n>-<UUID>
+**Display Name**         <Display name>               <i.n>-<UUID>                <Display name>              <i.n>-<UUID>
+**Hostname on the VM**   <Name>                       <i.n>-<UUID>                <Name>                      <i.n>-<UUID>
+**Name on vCenter**      i-<user\_id>-<vm\_id>-<Name> <i.n>-<UUID>                i-<user\_id>-<vm\_id>-<i.n> i-<user\_id>-<vm\_id>-<i.n>
+**Internal Name**        i-<user\_id>-<vm\_id>-<Name> i-<user\_id>-<vm\_id>-<i.n> i-<user\_id>-<vm\_id>-<i.n> i-<user\_id>-<vm\_id>-<i.n>
+======================== ============================ =========================== =========================== ===========================
+
+================== ==================== ============ ============== ================== ============================ ============================
+User-Provided Name vm.instancename.flag User         Display Name   Hostname on the VM Name on vCenter              Internal Name
+================== ==================== ============ ============== ================== ============================ ============================
+Yes                True                 <Name>       <Display name> <Name>             i-<user\_id>-<vm\_id>-<Name> i-<user\_id>-<vm\_id>-<Name>
+No                 True                 <i.n>-<UUID> <i.n>-<UUID>   <i.n>-<UUID>       <i.n>-<UUID>                 i-<user\_id>-<vm\_id>-<i.n>
+Yes                False                <Name>       <Display name> <Name>             i-<user\_id>-<vm\_id>-<i.n>  i-<user\_id>-<vm\_id>-<i.n>
+No                 False                <i.n>-<UUID> <i.n>-<UUID>   <i.n>-<UUID>       i-<user\_id>-<vm\_id>-<i.n>  i-<user\_id>-<vm\_id>-<i.n>
+================== ==================== ============ ============== ================== ============================ ============================
+
+   .. note::
+      <i.n> represents the value of global configuration - instance.name
 
 
 Changing the Service Offering for a VM

--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -322,28 +322,14 @@ To access a VM through the CloudStack UI:
 #. Click Apply.
 
 
-Appending a Display Name to the Guest VM’s Internal Name
+Appending VM Name to the Guest VM’s Internal Name
 ----------------------------------------------------------
 
-Every guest VM has an internal name. The host uses the internal name to
-identify the guest VMs. CloudStack gives you an option to provide a
-guest VM with a display name. You can set this display name as the
-internal name so that the vCenter can use it to identify the guest VM. A
-new global parameter, vm.instancename.flag, has now been added to
-achieve this functionality.
+Every guest VM has an internal name. The host uses the internal name to identify the guest VMs. CloudStack gives you an option to provide a guest VM with a  name. You can set this name as the internal name so that the vCenter can use it to identify the guest VM. A new global parameter, vm.instancename.flag, has now been added to achieve this functionality.
 
-The default format of the internal name is
-i-<user\_id>-<vm\_id>-<instance.name>, where instance.name is a global
-parameter. However, If vm.instancename.flag is set to true, and if a
-display name is provided during the creation of a guest VM, the display
-name is appended to the internal name of the guest VM on the host. This
-makes the internal name format as i-<user\_id>-<vm\_id>-<displayName>.
-The default value of vm.instancename.flag is set to false. This feature
-is intended to make the correlation between instance names and internal
-names easier in large data center deployments.
+The default format of the internal name is i-<user\_id>-<vm\_id>-<instance.name>, where instance.name is a global parameter. However, If vm.instancename.flag is set to true, and if a name is provided during the creation of a guest VM, the name is appended to the internal name of the guest VM on the host. This makes the internal name format as i-<user\_id>-<vm\_id>-<name>. The default value of vm.instancename.flag is set to false. This feature is intended to make the correlation between instance names and internal names easier in large data center deployments.
 
-The following table explains how a VM name is displayed in different
-scenarios.
+The following table explains how a VM name is displayed in different scenarios.
 
 .. cssclass:: table-striped table-bordered table-hover
 


### PR DESCRIPTION
Backend changes https://github.com/apache/cloudstack/pull/4581

Fixes VM naming convention.
VM name can be controlled with a combination of global settings, `vm.instancename.flag` and `instance.name` along with `name` parameter of `deployVirtualMachine` API. This PR highlights different cases.