### PR TITLE
Update kvm.rst

### DIFF
--- a/source/installguide/hypervisor/kvm.rst
+++ b/source/installguide/hypervisor/kvm.rst
@@ -613,7 +613,7 @@ Modify the interfaces file to look like this:
    auto cloudbr0
    iface cloudbr0 inet static
        bridge_ports eth0
-       bridge_fd 5
+       bridge_fd 0
        bridge_stp off
        bridge_maxwait 1
        address 192.168.42.11
@@ -626,7 +626,7 @@ Modify the interfaces file to look like this:
    auto cloudbr1
    iface cloudbr1 inet manual
        bridge_ports eth0.200
-       bridge_fd 5
+       bridge_fd 0
        bridge_stp off
        bridge_maxwait 1
 


### PR DESCRIPTION
From the [debian docs](https://wiki.debian.org/BridgeNetworkConnections),  the adviced parameters are

```
bridge_stp off       # disable Spanning Tree Protocol
bridge_waitport 0    # no delay before a port becomes available
bridge_fd 0          # no forwarding delay
bridge_ports none    # if you do not want to bind to any ports
bridge_ports regex eth* # use a regular expression to define ports
```