### PR TITLE
Remove IRC reference as it is no longer used

### DIFF
--- a/source/developersguide/get_help.rst
+++ b/source/developersguide/get_help.rst
@@ -27,14 +27,6 @@ Need some help getting started? Feel free to ask on the `mailing list
    discussions about development and the project itself happen. This is a high
    volume list.
 
-
-Or on one of the following IRC channels on irc.freenode.net:
-
--  #cloudstack - General Apache CloudStack conversation and end user support
--  #cloudstack-dev - Development discussions
--  #cloudstack-meeting - Weekly and ad-hoc meeting room for the Apache CloudStack community
-
-
 Documentation Available
 -----------------------
 


### PR DESCRIPTION
This PR addresses issue https://github.com/apache/cloudstack/issues/4880.

> Nowadays we mainly communicate via mailing list and Github issues/PRs. Additionally, the referenced IRC has no movement at all, and the fact that we are still marketing it as a point for discussions can give the wrong impression to newcomers, such as: "either the project is dead or documentation is outdated".