### PR TITLE
VMware vSphere datastore cluster synchronisation

### DIFF
--- a/source/adminguide/storage.rst
+++ b/source/adminguide/storage.rst
@@ -121,7 +121,7 @@ OCFS2. In this case the CloudStack does not attempt to mount or unmount
 the storage as is done with NFS. The CloudStack requires that the
 administrator insure that the storage is available
 
-VMware vSphere supports VMFS5, VMFS6, vSAN, vVols, DatastoreCluster storage types.
+VMware vSphere supports NFS, VMFS5, VMFS6, vSAN, vVols, DatastoreCluster storage types.
 For DatastoreCluster storage type, any changes to the datastore cluster
 at vCenter can be synchronised with CloudStack, like any addition of new
 child datastore to the DatastoreCluster or removal or existing child datastore

--- a/source/adminguide/storage.rst
+++ b/source/adminguide/storage.rst
@@ -121,6 +121,14 @@ OCFS2. In this case the CloudStack does not attempt to mount or unmount
 the storage as is done with NFS. The CloudStack requires that the
 administrator insure that the storage is available
 
+VMware vSphere supports VMFS5, VMFS6, vSAN, vVols, datastorecluster storage types.
+For datastorecluster storage type, any changes to the datastore cluster
+at vCenter can be synchronised with CloudStack, like any addition of new
+child datastore to the datastorecluster or removal or existing child datastore
+from the datastorecluster. Synchronisation of datastorecluster happens during
+host connect or storage pool maintenance operations or by calling the API
+syncStoragePool.
+
 With NFS storage, CloudStack manages the overprovisioning. In this case
 the global configuration parameter storage.overprovisioning.factor
 controls the degree of overprovisioning. This is independent of

--- a/source/adminguide/storage.rst
+++ b/source/adminguide/storage.rst
@@ -121,11 +121,11 @@ OCFS2. In this case the CloudStack does not attempt to mount or unmount
 the storage as is done with NFS. The CloudStack requires that the
 administrator insure that the storage is available
 
-VMware vSphere supports VMFS5, VMFS6, vSAN, vVols, datastorecluster storage types.
-For datastorecluster storage type, any changes to the datastore cluster
+VMware vSphere supports VMFS5, VMFS6, vSAN, vVols, DatastoreCluster storage types.
+For DatastoreCluster storage type, any changes to the datastore cluster
 at vCenter can be synchronised with CloudStack, like any addition of new
-child datastore to the datastorecluster or removal or existing child datastore
-from the datastorecluster. Synchronisation of datastorecluster happens during
+child datastore to the DatastoreCluster or removal or existing child datastore
+from the DatastoreCluster. Synchronisation of DatastoreCluster happens during
 host connect or storage pool maintenance operations or by calling the API
 syncStoragePool.
 

--- a/source/installguide/configuration.rst
+++ b/source/installguide/configuration.rst
@@ -678,9 +678,8 @@ Advanced Zone Configuration
 
    -  **Protocol.** For XenServer, choose either NFS, iSCSI, or
       PreSetup. For KVM, choose NFS, SharedMountPoint, CLVM, and RBD.
-      For vSphere choose either VMFS (iSCSI or FiberChannel) or NFS. The
-      remaining fields in the screen vary depending on what you choose
-      here.
+      For vSphere, choose either NFS, PreSetup (VMFS, vSAN, vVols) or datastorecluster.
+      The remaining fields in the screen vary depending on what you choose here.
 
       .. cssclass:: table-striped table-bordered table-hover
 

--- a/source/installguide/configuration.rst
+++ b/source/installguide/configuration.rst
@@ -678,7 +678,7 @@ Advanced Zone Configuration
 
    -  **Protocol.** For XenServer, choose either NFS, iSCSI, or
       PreSetup. For KVM, choose NFS, SharedMountPoint, CLVM, and RBD.
-      For vSphere, choose either NFS, PreSetup (VMFS, vSAN, vVols) or datastorecluster.
+      For vSphere, choose either NFS, PreSetup (VMFS, vSAN, vVols) or DatastoreCluster.
       The remaining fields in the screen vary depending on what you choose here.
 
       .. cssclass:: table-striped table-bordered table-hover
@@ -1181,19 +1181,19 @@ cluster.
 
    -  **Protocol.** For XenServer, choose either NFS, iSCSI, or
       PreSetup. For KVM, choose NFS or SharedMountPoint. For vSphere
-      choose either NFS, PreSetup (VMFS, vSAN, vVols) or datastorecluster. For Hyper-V,
+      choose either NFS, PreSetup (VMFS, vSAN, vVols) or DatastoreCluster. For Hyper-V,
       choose SMB.
 
    -  **Server (for NFS, iSCSI, or PreSetup).** The IP address or DNS
       name of the storage device.
 
-   -  **Server (for PreSetup or datastorecluster).** The IP address or DNS name of the vCenter
+   -  **Server (for PreSetup or DatastoreCluster).** The IP address or DNS name of the vCenter
       server.
 
    -  **Path (for NFS).** In NFS this is the exported path from the
       server.
 
-   -  **Path (for PreSetup or datastorecluster).** In vSphere this is a combination of the
+   -  **Path (for PreSetup or DatastoreCluster).** In vSphere this is a combination of the
       datacenter name and the datastore or datastore cluster name. The format is "/"
       datacenter name "/" datastore or datastore cluster name. For example,
       "/cloud.dc.VM/cluster1datastore".

--- a/source/installguide/configuration.rst
+++ b/source/installguide/configuration.rst
@@ -678,7 +678,7 @@ Advanced Zone Configuration
 
    -  **Protocol.** For XenServer, choose either NFS, iSCSI, or
       PreSetup. For KVM, choose NFS, SharedMountPoint, CLVM, and RBD.
-      For vSphere, choose either NFS, PreSetup (VMFS, vSAN, vVols) or DatastoreCluster.
+      For vSphere, choose either NFS, PreSetup (VMFS - iSCSI/FiberChannel, vSAN, vVols) or DatastoreCluster.
       The remaining fields in the screen vary depending on what you choose here.
 
       .. cssclass:: table-striped table-bordered table-hover
@@ -1181,7 +1181,7 @@ cluster.
 
    -  **Protocol.** For XenServer, choose either NFS, iSCSI, or
       PreSetup. For KVM, choose NFS or SharedMountPoint. For vSphere
-      choose either NFS, PreSetup (VMFS, vSAN, vVols) or DatastoreCluster. For Hyper-V,
+      choose either NFS, PreSetup (VMFS - iSCSI/FiberChannel, vSAN, vVols) or DatastoreCluster. For Hyper-V,
       choose SMB.
 
    -  **Server (for NFS, iSCSI, or PreSetup).** The IP address or DNS


### PR DESCRIPTION
These documentation changes are related to the improvement PR https://github.com/apache/cloudstack/pull/4871
In VMware vSphere, primary storage datastore cluster can be now synchronised with CloudStack upon any changes on the datastore cluster at vCenter. If any new child datastore is added to datastore cluster or if any existing child datastore is removed from the datastore cluster at vCenter then these changes can be synchronised with datastore cluster in CloudStack primary storage.