### PR TITLE
vm: note about read-only details

### DIFF
--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -738,22 +738,27 @@ already in use by the VM.
 Advanced VM Instance Settings
 -----------------------------
 
-Each user VM has a set of "details" associated with it (as visible via listVirtualMachine API call) - those "details" are shown on the "Settings" tab of the VM in the GUI (words "setting(s)" and "detail(s)" are here used interchangeably). 
+Each user VM has a set of "details" associated with it (as visible via listVirtualMachine API call) - those "details" are shown on the "Settings" tab of the VM in the GUI (words "setting(s)" and "detail(s)" are here used interchangeably).
 
-The Settings tab is always present/visible, but settings can be changed only when the VM is in a Stopped state. 
-Some VM details/settings can be hidden via "user.vm.blacklisted.details" global setting (you can find below the list of those hidden by default).
+The Settings tab is always present/visible, but settings can be changed only when the VM is in a Stopped state.
+Some VM details/settings can be hidden for users via "user.vm.blacklisted.details" global setting. VM details/settings can also be made read-only for users using "user.vm.readonly.details" global setting. List of default hidden and read-only details/settings is given below.
 
 .. note::
    Since version 4.15, VMware VM settings for the ROOT disk controller, NIC adapter type and data disk controller are populated automatically with the values inherited from the template.
 
 When adding a new setting or modifying the existing ones, setting names are shown/offered in a drop-down list, as well as their possible values (with the exception of boolean or numerical values).
 
-Read-only details/settings that are hidden by default:
+Details/settings that are hidden for users by default:
 
 - rootdisksize
-- cpuOvercommitRatio 
-- memoryOvercommitRatio 
+- cpuOvercommitRatio
+- memoryOvercommitRatio
 - Message.ReservedCapacityFreed.Flag
+
+Details/settings that are read-only for users by default:
+
+- dataDiskController
+- rootDiskController
 
 An example list of settings as well as their possible values are shown on the images below:
 


### PR DESCRIPTION
Adds a note about VM read-only details for users.

Related: https://github.com/apache/cloudstack/pull/4671