### PR TITLE
Added workaround for vm name sequence error

### DIFF
--- a/source/installguide/hypervisor/vsphere.rst
+++ b/source/installguide/hypervisor/vsphere.rst
@@ -61,7 +61,7 @@ Software requirements:
 
    UPDATE cloud.sequence
    SET value = 1000000
-   WHERE name = 'vm_instance_seq'
+   WHERE name = 'vm_instance_seq';
 
 Hardware requirements:
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/source/installguide/hypervisor/vsphere.rst
+++ b/source/installguide/hypervisor/vsphere.rst
@@ -51,6 +51,17 @@ Software requirements:
    Apply All Necessary Hotfixes. The lack of up-do-date hotfixes can lead to 
    data corruption and lost VMs.
 
+.. note::
+
+   When using vSphere and vCenter versions 6.0 and 6.5 there is a limitation on
+   instance names with a sequence number between 99999 and 1000000. For example if you take
+   a snapshot of a VM, the expected filename will be different to what cloudstack expects.
+   It is advisable to set the sequence number to 1M to prevent issues by executing the
+   following script on your cloudstack database:
+
+   UPDATE cloud.sequence
+   SET value = 1000000
+   WHERE name = 'vm_instance_seq'
 
 Hardware requirements:
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
.vmx file names are changed when creating a snapshot when the vm name sequence number falls between 99999 and 1000000 and using vmware 6.0 and 6.5. 

This PR adds a fix to the documentation