### PR TITLE
compat: drop .x from centos/rhel versions

### DIFF
--- a/source/releasenotes/compat.rst
+++ b/source/releasenotes/compat.rst
@@ -23,8 +23,8 @@ This section lists the operating systems that are supported for running
 CloudStack Management Server.
 
 -  Ubuntu 16.04 LTS, 18.04 LTS, 20.04 LTS
--  CentOS versions 7.x, 8.x (note: CentOS 8 will EOL in Dec 2021)
--  RHEL versions 7.x, 8.x
+-  CentOS versions 7, 8 (note: CentOS 8 will EOL in Dec 2021)
+-  RHEL versions 7, 8
 
 Software Requirements
 ~~~~~~~~~~~~~~~~~~~~~
@@ -39,8 +39,8 @@ CloudStack supports three hypervisor families, XenServer with XAPI, KVM,
 and VMware with vSphere.
 
 -  Ubuntu 16.04 LTS, 18.04, 20.04 LTS with KVM
--  CentOS 7.x, 8.x with KVM (note: CentOS 8 will EOL in Dec 2021)
--  Red Hat Enterprise Linux 7.x, 8.x with KVM
+-  CentOS 7, 8 with KVM (note: CentOS 8 will EOL in Dec 2021)
+-  Red Hat Enterprise Linux 7, 8 with KVM
 -  XenServer versions 7.0, 7.1, 7.2, 7.4, 7.5, 8.0 with latest hotfixes, XCP-ng 7.4, 7.6, 8.0, 8.1
 
    .. note:: It is now required to enable HA on the XenServer pool in order to recover from a pool-master failure. Please refer to the `XenServer documentation <https://docs.citrix.com/en-us/xencenter/7-1/pools-ha-enable.html>`_.


### PR DESCRIPTION
CentOS7, CentOS8 is distro; we assume people to upgrade to latest .x
as it may be the case that upgrade to latest CloudStack version forces
some packages/dependencies to upgrade.