### PR TITLE
Add interfaces name prefixes for KVM bridges

### DIFF
--- a/source/installguide/hypervisor/kvm.rst
+++ b/source/installguide/hypervisor/kvm.rst
@@ -455,6 +455,12 @@ infrastructure.
 By default these bridges are called *cloudbr0* and *cloudbr1* etc, but this can be 
 changed to be more description. 
 
+.. note::
+   Ensure that the interfaces names to be used for configuring the bridges match one of the following patterns:
+   **'eth*', 'bond*', 'team*', 'vlan*', 'em*', 'p*p*', 'ens*', 'eno*', 'enp*', 'enx*'**.
+
+   Otherwise, the KVM agent will not be able to configure the bridges properly.
+
 .. warning::
    It is essential that you keep the configuration consistent across all of your hypervisors.
 


### PR DESCRIPTION
Add a note to consider for interfaces names when configuring bridges for KVM networking. Otherwise, the agent will fail to be configured with error:

````
2021-05-13 18:53:08,587 DEBUG [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-5:null) (logid:4b3902b9) matchPifFileInDirectory: file name 'cdbr_bond1'
2021-05-13 18:53:08,587 DEBUG [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-5:null) (logid:4b3902b9) failing to get physical interface from bridge cloudbr1, did not find an eth*, bond*, team*, vlan*, em*, p*p*, ens*, eno*, enp*, or enx* in /sys/devices/virtual/net/cloudbr1/brif
````