### PR TITLE
Remove Java and Timezone notices - when upgrading from 4.14+

### DIFF
--- a/source/upgrading/upgrade/upgrade-4.14.rst
+++ b/source/upgrading/upgrade/upgrade-4.14.rst
@@ -37,10 +37,8 @@ Overview of Upgrade Steps:
 
 #. Check any customisations and integrations
 #. Upload the |sysvm64-version| System VM template if not already using it.
-#. Confirm Java 11 is the default Java version
 #. Stop all running management servers
 #. Backup CloudStack database (MySQL)
-#. Add "serverTimezone=UTC" to your "db.properties"
 #. Upgrade 1st CloudStack management server
 #. Update hypervisors specific dependencies
 #. Restart 1st management server
@@ -56,8 +54,6 @@ Overview of Upgrade Steps:
     CloudStack packages.
 
 .. include:: _sysvm_templates.rst
-
-.. include:: _java_version.rst
 
 Packages repository
 -------------------
@@ -110,8 +106,6 @@ Backup current database
 
 Management Server
 -----------------
-
-.. include:: _timezone.rst
 
 Ubuntu
 ######

--- a/source/upgrading/upgrade/upgrade-4.15.rst
+++ b/source/upgrading/upgrade/upgrade-4.15.rst
@@ -37,10 +37,8 @@ Overview of Upgrade Steps:
 
 #. Check any customisations and integrations
 #. Upload the |sysvm64-version| System VM template if not already using it.
-#. Confirm Java 11 is the default Java version
 #. Stop all running management servers
 #. Backup CloudStack database (MySQL)
-#. Add "serverTimezone=UTC" to your "db.properties"
 #. Upgrade 1st CloudStack management server
 #. Update hypervisors specific dependencies
 #. Restart 1st management server
@@ -57,7 +55,6 @@ Overview of Upgrade Steps:
 
 .. include:: _sysvm_templates.rst
 
-.. include:: _java_version.rst
 
 Packages repository
 -------------------
@@ -110,8 +107,6 @@ Backup current database
 
 Management Server
 -----------------
-
-.. include:: _timezone.rst
 
 Ubuntu
 ######


### PR DESCRIPTION
Removed the notice about Java 11 version and timezone in my.cnf or db.properties - as these already HAVE to be in place in order to even run the 4.15.0 (this is upgrade page FROM 4.15.0 to 4.15.1).

ping @rhtyd @DaanHoogland  for review pls (need to do the same for upgrade FROM 4.14)