### PR TITLE
network: note on shared networks with IPv6

### DIFF
--- a/source/plugins/ipv6.rst
+++ b/source/plugins/ipv6.rst
@@ -79,7 +79,7 @@ Consider the following:
    IPv6 in shared network; the choice of Default Network will not affect
    the routing in the user VM.
 
--  A shared network  cannot be IPv6 only. Therefore, it is necessary to configure the IPv4 address range for the shared network with IPv6 addresses. The IPv4 range can be of a public or internal IPv4 network.
+-  A shared network cannot be IPv6 only. Therefore, it is necessary to configure the IPv4 address range for the shared network with IPv6 addresses. The IPv4 range can be of a public or internal IPv4 network.
 
 -  In a multiple shared network, the default route is set by the rack
    router, rather than the DHCP server, which is out of CloudStack

--- a/source/plugins/ipv6.rst
+++ b/source/plugins/ipv6.rst
@@ -79,6 +79,8 @@ Consider the following:
    IPv6 in shared network; the choice of Default Network will not affect
    the routing in the user VM.
 
+-  A shared network  cannot be IPv6 only. Therefore, it is necessary to configure the IPv4 address range for the shared network with IPv6 addresses. The IPv4 range can be of a public or internal IPv4 network.
+
 -  In a multiple shared network, the default route is set by the rack
    router, rather than the DHCP server, which is out of CloudStack
    control. Therefore, in order for the user VM to get only the default


### PR DESCRIPTION
Shared networks with IPv6 only cannot work. NPE is observed with MAC address of VM's NIC when a VM is deployed or added to such networks.

```
TransactionCallbackWithExceptionNoReturn.doInTransaction:25-TransactionCallbackWithExceptionNoReturn.doInTransaction:21-Transaction.execute:40-DirectNetworkGuru.allocateDirectIp:280-DirectNetworkGuru.allocate:253-NetworkOrchestrator.allocateNic:951
2021-07-14 05:21:19,724 ERROR [c.c.a.ApiServer] (qtp109228794-1826:ctx-0f190552 ctx-dde78569) (logid:60f9ec82) unhandled exception executing api command: [Ljava.lang.String;@3f6b9f6b
java.lang.NullPointerException
	at com.cloud.utils.net.NetUtils.EUI64Address(NetUtils.java:1626)
```

Also discussed in https://github.com/apache/cloudstack/issues/4563#issuecomment-794024295