### PR TITLE
Fix for custom repository URL

### DIFF
--- a/source/installguide/building_from_source.rst
+++ b/source/installguide/building_from_source.rst
@@ -393,7 +393,7 @@ on your target system first.
    $ wget -q -O - <http://server.url>/cloudstack/repo/binary/KEY.gpg | sudo apt-key add -
 
 .. note::
-   In the previous lines the variable <http://server.url> must be replaced with the URL of the repository
+   In the previous lines the variable <server.url> must be replaced with the address of the repository
 
 Now that you have the repository info in place, you'll want to run
 another update so that APT knows where to find the CloudStack packages.

--- a/source/installguide/building_from_source.rst
+++ b/source/installguide/building_from_source.rst
@@ -383,14 +383,17 @@ line:
 
 .. parsed-literal::
 
-   deb http://server.url/cloudstack/repo/binary ./
+   deb <http://server.url>/cloudstack/repo/binary ./
 
 If you signed your Release file with GnuPG, import the signing key
 on your target system first.
 
 .. parsed-literal::
 
-   $ wget -q -O - http://server.url/cloudstack/repo/binary/KEY.gpg | sudo apt-key add -
+   $ wget -q -O - <http://server.url>/cloudstack/repo/binary/KEY.gpg | sudo apt-key add -
+
+.. note::
+   In the previous lines the variable <http://server.url> must be replaced with the URL of the repository
 
 Now that you have the repository info in place, you'll want to run
 another update so that APT knows where to find the CloudStack packages.

--- a/source/installguide/building_from_source.rst
+++ b/source/installguide/building_from_source.rst
@@ -390,7 +390,7 @@ on your target system first.
 
 .. parsed-literal::
 
-   $ wget -q -O - <http://server.url>/cloudstack/repo/binary/KEY.gpg | sudo apt-key add -
+   $ wget -q -O - http://<server.url>/cloudstack/repo/binary/KEY.gpg | sudo apt-key add -
 
 .. note::
    In the previous lines the variable <server.url> must be replaced with the address of the repository

--- a/source/installguide/building_from_source.rst
+++ b/source/installguide/building_from_source.rst
@@ -383,7 +383,7 @@ line:
 
 .. parsed-literal::
 
-   deb <http://server.url>/cloudstack/repo/binary ./
+   deb http://<server.url>/cloudstack/repo/binary ./
 
 If you signed your Release file with GnuPG, import the signing key
 on your target system first.


### PR DESCRIPTION
Fixes: https://github.com/apache/cloudstack/issues/5188

Explicitly add a variable URL to indicate the lines refer to a custom repository