### PR TITLE
MySQL sql_mode change

### DIFF
--- a/source/upgrading/upgrade/upgrade_notes.rst
+++ b/source/upgrading/upgrade/upgrade_notes.rst
@@ -106,13 +106,18 @@ added in CloudStack's db.properties file:
 MySQL 8.0 sql mode change
 -------------------------
 
-MySQL mode (sql_mode) has changed in CloudStack db.properties to "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION".
+MySQL mode (sql_mode) has changed in CloudStack db.properties to 
+"STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,
+ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION".
+
 This gets automatically applies to the MySQL session used by CloudStack management server.
 
 If the admin uses MySQL directly and wants to query tables it is advised to change the sql_mode in the corresponding session or globally.
 
-Eg. mysql> set global sql_mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION";
+Eg. mysql> set global sql_mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,
+                             "> ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION";
     Query OK, 0 rows affected (0.00 sec)
 
-    mysql> set sql_mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION";
+    mysql> set sql_mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,
+                     "> ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION";
     Query OK, 0 rows affected (0.00 sec)

--- a/source/upgrading/upgrade/upgrade_notes.rst
+++ b/source/upgrading/upgrade/upgrade_notes.rst
@@ -101,3 +101,18 @@ added in CloudStack's db.properties file:
    db.cloud.driver=jdbc:mysql
 
    db.usage.driver=jdbc:mysql
+
+
+MySQL 8.0 sql mode change
+-------------------------
+
+MySQL mode (sql_mode) has changed in CloudStack db.properties to "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION".
+This gets automatically applies to the MySQL session used by CloudStack management server.
+
+If the admin uses MySQL directly and wants to query tables it is advised to change the sql_mode in the corresponding session or globally.
+
+Eg. mysql> set global sql_mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION";
+    Query OK, 0 rows affected (0.00 sec)
+
+    mysql> set sql_mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION";
+    Query OK, 0 rows affected (0.00 sec)


### PR DESCRIPTION
MySQL sql_mode has changed and if the admin uses MySQL directly and wants to query tables it is advised to change the sql_mode in the corresponding session or globally.

Eg. mysql> set global sql_mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION";
Query OK, 0 rows affected (0.00 sec)
