### PR TITLE
Add a document to config footer text

### DIFF
--- a/source/adminguide/ui.rst
+++ b/source/adminguide/ui.rst
@@ -192,8 +192,8 @@ apiBase      Changes the suffix for the API endpoint
 docBase      Changes the base URL for the documentation
 appTitle     Changes the title of the portal
 footer       Changes the footer text
-logo         Changes the logo top-left side image
 loginFooter  Configure to display text (HTML) in the footer at the login screen.
+logo         Changes the logo top-left side image
 banner       Changes the login banner image
 error.404    Changes the image of error Page not found
 error.403    Changes the image of error Forbidden

--- a/source/adminguide/ui.rst
+++ b/source/adminguide/ui.rst
@@ -535,6 +535,7 @@ For the UI to work with different servers, it is necessary to configure the Ngin
 
 Footer text option
 ~~~~~~~~~~~~~~~~~~
+
 Users can use the file `/etc/cloudstack/management/config.json` to add the option to display text in the footer at the login screen to show where to get help or display a usage policy.
 
 To display the text in the footer at the login screen, make the following changes to the config.json file:

--- a/source/adminguide/ui.rst
+++ b/source/adminguide/ui.rst
@@ -185,9 +185,9 @@ Users can customize the CloudStack's user interface by means of a configuration 
 
 To change the logo, login banner, error page icon, etc. the following details can be edited in config.json:
 
-============= ================================================================
+============================= ================================================================
 Property                      Description
-============= ================================================================
+============================= ================================================================
 apiBase                       Changes the suffix for the API endpoint
 docBase                       Changes the base URL for the documentation
 appTitle                      Changes the title of the portal
@@ -198,7 +198,7 @@ banner                        Changes the login banner image
 error.404                     Changes the image of error Page not found
 error.403                     Changes the image of error Forbidden
 error.500                     Changes the image of error Internal Server Error.
-============ ================================================================
+============================= ================================================================
 
 .. parsed-literal::
 

--- a/source/adminguide/ui.rst
+++ b/source/adminguide/ui.rst
@@ -543,13 +543,13 @@ To display the text in the footer at the login screen, make the following change
 ============================= ===================================================================
 Property                      Description
 ============================= ===================================================================
-footerText                    Configure to display text (HTML) in the footer at the login screen.
+loginFooter                   Configure to display text (HTML) in the footer at the login screen.
 ============================= ===================================================================
 
 .. parsed-literal::
    {
       ...
-      footerText: "By logging, you are accepting the <a href='https://www.apache.org/foundation/policies/privacy.html'>usage policy</a>"
+      loginFooter: "By logging, you are accepting the <a href='https://www.apache.org/foundation/policies/privacy.html'>usage policy</a>"
    }
 
 Known Limitations

--- a/source/adminguide/ui.rst
+++ b/source/adminguide/ui.rst
@@ -185,20 +185,20 @@ Users can customize the CloudStack's user interface by means of a configuration 
 
 To change the logo, login banner, error page icon, etc. the following details can be edited in config.json:
 
-==========   ==================================================
-Property     Description
-==========   ==================================================
-apiBase      Changes the suffix for the API endpoint
-docBase      Changes the base URL for the documentation
-appTitle     Changes the title of the portal
-footer       Changes the footer text
-loginFooter  Configure to display text (HTML) in the footer at the login screen.
-logo         Changes the logo top-left side image
-banner       Changes the login banner image
-error.404    Changes the image of error Page not found
-error.403    Changes the image of error Forbidden
-error.500    Changes the image of error Internal Server Error.
-========== ==================================================
+============= ================================================================
+Property                      Description
+============= ================================================================
+apiBase                       Changes the suffix for the API endpoint
+docBase                       Changes the base URL for the documentation
+appTitle                      Changes the title of the portal
+footer                        Changes the footer text
+loginFooter                   Configure to display text (HTML) in the footer at the login screen.
+logo                          Changes the logo top-left side image
+banner                        Changes the login banner image
+error.404                     Changes the image of error Page not found
+error.403                     Changes the image of error Forbidden
+error.500                     Changes the image of error Internal Server Error.
+============ ================================================================
 
 .. parsed-literal::
 

--- a/source/adminguide/ui.rst
+++ b/source/adminguide/ui.rst
@@ -533,6 +533,24 @@ For the UI to work with different servers, it is necessary to configure the Ngin
 
 |ui-multiple-server-management.png|
 
+Footer text option
+~~~~~~~~~~~~~~~~~~
+Users can use the file `/etc/cloudstack/management/config.json` to add the option to display text in the footer at the login screen to show where to get help or display a usage policy.
+
+To display the text in the footer at the login screen, make the following changes to the config.json file:
+
+============================= ===================================================================
+Property                      Description
+============================= ===================================================================
+footerText                    Configure to display text (HTML) in the footer at the login screen.
+============================= ===================================================================
+
+.. parsed-literal::
+   {
+      ...
+      footerText: "By logging, you are accepting the <a href='https://www.apache.org/foundation/policies/privacy.html'>usage policy</a>"
+   }
+
 Known Limitations
 ~~~~~~~~~~~~~~~~~
 

--- a/source/adminguide/ui.rst
+++ b/source/adminguide/ui.rst
@@ -185,18 +185,19 @@ Users can customize the CloudStack's user interface by means of a configuration 
 
 To change the logo, login banner, error page icon, etc. the following details can be edited in config.json:
 
-========== ==================================================
-Property   Description
-========== ==================================================
-apiBase    Changes the suffix for the API endpoint
-docBase    Changes the base URL for the documentation
-appTitle   Changes the title of the portal
-footer     Changes the footer text
-logo       Changes the logo top-left side image
-banner     Changes the login banner image
-error.404  Changes the image of error Page not found
-error.403  Changes the image of error Forbidden
-error.500  Changes the image of error Internal Server Error.
+==========   ==================================================
+Property     Description
+==========   ==================================================
+apiBase      Changes the suffix for the API endpoint
+docBase      Changes the base URL for the documentation
+appTitle     Changes the title of the portal
+footer       Changes the footer text
+logo         Changes the logo top-left side image
+loginFooter  Configure to display text (HTML) in the footer at the login screen.
+banner       Changes the login banner image
+error.404    Changes the image of error Page not found
+error.403    Changes the image of error Forbidden
+error.500    Changes the image of error Internal Server Error.
 ========== ==================================================
 
 .. parsed-literal::
@@ -205,6 +206,7 @@ error.500  Changes the image of error Internal Server Error.
     "docBase": "http://docs.cloudstack.apache.org/en/latest",
     "appTitle": "CloudStack",
     "footer": "Licensed under the <a href='http://www.apache.org/licenses/' target='_blank'>Apache License</a>, Version 2.0.",
+    "loginFooter": "By logging, you are accepting the <a href='https://www.apache.org/foundation/policies/privacy.html'>usage policy</a>",
     "logo": "assets/logo.svg",
     "banner": "assets/banner.svg",
     "error": {
@@ -532,25 +534,6 @@ For the UI to work with different servers, it is necessary to configure the Ngin
    }
 
 |ui-multiple-server-management.png|
-
-Footer text option
-~~~~~~~~~~~~~~~~~~
-
-Users can use the file `/etc/cloudstack/management/config.json` to add the option to display text in the footer at the login screen to show where to get help or display a usage policy.
-
-To display the text in the footer at the login screen, make the following changes to the config.json file:
-
-============================= ===================================================================
-Property                      Description
-============================= ===================================================================
-loginFooter                   Configure to display text (HTML) in the footer at the login screen.
-============================= ===================================================================
-
-.. parsed-literal::
-   {
-      ...
-      loginFooter: "By logging, you are accepting the <a href='https://www.apache.org/foundation/policies/privacy.html'>usage policy</a>"
-   }
 
 Known Limitations
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Related https://github.com/apache/cloudstack/pull/5628.
The documentation allows configuring a footer text at the Login screen.