### PR TITLE
Fix mysqldump missing 'Grave Accent'

### DIFF
--- a/source/upgrading/upgrade/upgrade-4.10.rst
+++ b/source/upgrading/upgrade/upgrade-4.10.rst
@@ -104,8 +104,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
 
 
 .. _ubuntu410:

--- a/source/upgrading/upgrade/upgrade-4.10.rst
+++ b/source/upgrading/upgrade/upgrade-4.10.rst
@@ -104,8 +104,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_$(date '+%Y-%m-%d').sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_$(date +%Y-%m-%d-%H%M%S)
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date +%Y-%m-%d-%H%M%S)
 
 
 .. _ubuntu410:

--- a/source/upgrading/upgrade/upgrade-4.10.rst
+++ b/source/upgrading/upgrade/upgrade-4.10.rst
@@ -104,8 +104,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
 
 
 .. _ubuntu410:

--- a/source/upgrading/upgrade/upgrade-4.11.rst
+++ b/source/upgrading/upgrade/upgrade-4.11.rst
@@ -100,8 +100,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
 
 
 .. _ubuntu411:

--- a/source/upgrading/upgrade/upgrade-4.11.rst
+++ b/source/upgrading/upgrade/upgrade-4.11.rst
@@ -100,8 +100,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
 
 
 .. _ubuntu411:

--- a/source/upgrading/upgrade/upgrade-4.11.rst
+++ b/source/upgrading/upgrade/upgrade-4.11.rst
@@ -100,8 +100,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_$(date '+%Y-%m-%d').sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_$(date +%Y-%m-%d-%H%M%S)
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date +%Y-%m-%d-%H%M%S)
 
 
 .. _ubuntu411:

--- a/source/upgrading/upgrade/upgrade-4.12.rst
+++ b/source/upgrading/upgrade/upgrade-4.12.rst
@@ -98,8 +98,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
 
 
 .. _ubuntu412:

--- a/source/upgrading/upgrade/upgrade-4.12.rst
+++ b/source/upgrading/upgrade/upgrade-4.12.rst
@@ -98,8 +98,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_$(date '+%Y-%m-%d').sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_$(date +%Y-%m-%d-%H%M%S)
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date +%Y-%m-%d-%H%M%S)
 
 
 .. _ubuntu412:

--- a/source/upgrading/upgrade/upgrade-4.12.rst
+++ b/source/upgrading/upgrade/upgrade-4.12.rst
@@ -98,8 +98,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
 
 
 .. _ubuntu412:

--- a/source/upgrading/upgrade/upgrade-4.13.rst
+++ b/source/upgrading/upgrade/upgrade-4.13.rst
@@ -101,8 +101,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
 
 
 .. _ubuntu413:

--- a/source/upgrading/upgrade/upgrade-4.13.rst
+++ b/source/upgrading/upgrade/upgrade-4.13.rst
@@ -101,8 +101,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
 
 
 .. _ubuntu413:

--- a/source/upgrading/upgrade/upgrade-4.13.rst
+++ b/source/upgrading/upgrade/upgrade-4.13.rst
@@ -101,8 +101,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_$(date '+%Y-%m-%d').sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_$(date +%Y-%m-%d-%H%M%S)
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date +%Y-%m-%d-%H%M%S)
 
 
 .. _ubuntu413:

--- a/source/upgrading/upgrade/upgrade-4.14.rst
+++ b/source/upgrading/upgrade/upgrade-4.14.rst
@@ -97,8 +97,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_$(date '+%Y-%m-%d').sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_$(date +%Y-%m-%d-%H%M%S)
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date +%Y-%m-%d-%H%M%S)
 
 
 .. _ubuntu414:

--- a/source/upgrading/upgrade/upgrade-4.14.rst
+++ b/source/upgrading/upgrade/upgrade-4.14.rst
@@ -97,8 +97,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
 
 
 .. _ubuntu414:

--- a/source/upgrading/upgrade/upgrade-4.14.rst
+++ b/source/upgrading/upgrade/upgrade-4.14.rst
@@ -97,8 +97,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
 
 
 .. _ubuntu414:

--- a/source/upgrading/upgrade/upgrade-4.15.rst
+++ b/source/upgrading/upgrade/upgrade-4.15.rst
@@ -98,8 +98,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_$(date '+%Y-%m-%d').sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_$(date +%Y-%m-%d-%H%M%S)
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date +%Y-%m-%d-%H%M%S)
 
 
 .. _ubuntu414:

--- a/source/upgrading/upgrade/upgrade-4.15.rst
+++ b/source/upgrading/upgrade/upgrade-4.15.rst
@@ -98,8 +98,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
 
 
 .. _ubuntu414:

--- a/source/upgrading/upgrade/upgrade-4.15.rst
+++ b/source/upgrading/upgrade/upgrade-4.15.rst
@@ -98,8 +98,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p -R cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p -R cloud > cloud-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
 
 
 .. _ubuntu414:

--- a/source/upgrading/upgrade/upgrade-4.2.rst
+++ b/source/upgrading/upgrade/upgrade-4.2.rst
@@ -84,8 +84,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_$(date '+%Y-%m-%d').sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud > cloud-backup_$(date +%Y-%m-%d-%H%M%S)
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date +%Y-%m-%d-%H%M%S)
 
 
 .. _ubuntu42:

--- a/source/upgrading/upgrade/upgrade-4.2.rst
+++ b/source/upgrading/upgrade/upgrade-4.2.rst
@@ -84,8 +84,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud > cloud-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
 
 
 .. _ubuntu42:

--- a/source/upgrading/upgrade/upgrade-4.2.rst
+++ b/source/upgrading/upgrade/upgrade-4.2.rst
@@ -84,8 +84,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
+      $ mysqldump -u root -p cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
 
 
 .. _ubuntu42:

--- a/source/upgrading/upgrade/upgrade-4.3.rst
+++ b/source/upgrading/upgrade/upgrade-4.3.rst
@@ -88,8 +88,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud > cloud-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
 
 
 .. _ubuntu43:

--- a/source/upgrading/upgrade/upgrade-4.3.rst
+++ b/source/upgrading/upgrade/upgrade-4.3.rst
@@ -88,8 +88,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
+      $ mysqldump -u root -p cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
 
 
 .. _ubuntu43:

--- a/source/upgrading/upgrade/upgrade-4.3.rst
+++ b/source/upgrading/upgrade/upgrade-4.3.rst
@@ -88,8 +88,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_$(date '+%Y-%m-%d').sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud > cloud-backup_$(date +%Y-%m-%d-%H%M%S)
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date +%Y-%m-%d-%H%M%S)
 
 
 .. _ubuntu43:

--- a/source/upgrading/upgrade/upgrade-4.4.rst
+++ b/source/upgrading/upgrade/upgrade-4.4.rst
@@ -88,8 +88,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
+      $ mysqldump -u root -p cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
 
 
 .. _ubuntu44:

--- a/source/upgrading/upgrade/upgrade-4.4.rst
+++ b/source/upgrading/upgrade/upgrade-4.4.rst
@@ -88,8 +88,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud > cloud-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
 
 
 .. _ubuntu44:

--- a/source/upgrading/upgrade/upgrade-4.4.rst
+++ b/source/upgrading/upgrade/upgrade-4.4.rst
@@ -88,8 +88,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_$(date '+%Y-%m-%d').sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud > cloud-backup_$(date +%Y-%m-%d-%H%M%S)
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date +%Y-%m-%d-%H%M%S)
 
 
 .. _ubuntu44:

--- a/source/upgrading/upgrade/upgrade-4.5.rst
+++ b/source/upgrading/upgrade/upgrade-4.5.rst
@@ -97,8 +97,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud > cloud-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
 
 
 .. _ubuntu45:

--- a/source/upgrading/upgrade/upgrade-4.5.rst
+++ b/source/upgrading/upgrade/upgrade-4.5.rst
@@ -97,8 +97,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
+      $ mysqldump -u root -p cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
 
 
 .. _ubuntu45:

--- a/source/upgrading/upgrade/upgrade-4.5.rst
+++ b/source/upgrading/upgrade/upgrade-4.5.rst
@@ -97,8 +97,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_$(date '+%Y-%m-%d').sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud > cloud-backup_$(date +%Y-%m-%d-%H%M%S)
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date +%Y-%m-%d-%H%M%S)
 
 
 .. _ubuntu45:

--- a/source/upgrading/upgrade/upgrade-4.6.rst
+++ b/source/upgrading/upgrade/upgrade-4.6.rst
@@ -86,8 +86,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
+      $ mysqldump -u root -p cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
 
 
 .. _ubuntu46:

--- a/source/upgrading/upgrade/upgrade-4.6.rst
+++ b/source/upgrading/upgrade/upgrade-4.6.rst
@@ -86,8 +86,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud > cloud-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
 
 
 .. _ubuntu46:

--- a/source/upgrading/upgrade/upgrade-4.6.rst
+++ b/source/upgrading/upgrade/upgrade-4.6.rst
@@ -86,8 +86,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_$(date '+%Y-%m-%d').sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud > cloud-backup_$(date +%Y-%m-%d-%H%M%S)
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date +%Y-%m-%d-%H%M%S)
 
 
 .. _ubuntu46:

--- a/source/upgrading/upgrade/upgrade-4.7.rst
+++ b/source/upgrading/upgrade/upgrade-4.7.rst
@@ -85,8 +85,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud > cloud-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
 
 
 .. _ubuntu47:

--- a/source/upgrading/upgrade/upgrade-4.7.rst
+++ b/source/upgrading/upgrade/upgrade-4.7.rst
@@ -85,8 +85,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
+      $ mysqldump -u root -p cloud > cloud-backup_\\`date '+%Y-%m-%d'\\`.sql
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_\\`date '+%Y-%m-%d'\\`.sql
 
 
 .. _ubuntu47:

--- a/source/upgrading/upgrade/upgrade-4.7.rst
+++ b/source/upgrading/upgrade/upgrade-4.7.rst
@@ -85,8 +85,8 @@ Backup current database
 
    .. parsed-literal::
 
-      $ mysqldump -u root -p cloud > cloud-backup_$(date '+%Y-%m-%d').sql
-      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date '+%Y-%m-%d').sql
+      $ mysqldump -u root -p cloud > cloud-backup_$(date +%Y-%m-%d-%H%M%S)
+      $ mysqldump -u root -p cloud_usage > cloud_usage-backup_$(date +%Y-%m-%d-%H%M%S)
 
 
 .. _ubuntu47:


### PR DESCRIPTION
Fix mysqldump command in the ["Database Preparation"](https://docs.cloudstack.apache.org/en/4.16.0.0/upgrading/upgrade/upgrade-4.15.html#database-preparation) section.

Nowadays it is:
```
$ mysqldump -u root -p -R cloud > cloud-backup_`date '+%Y-%m-%d'.sql
$ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'.sql
```
This won't work as it is missing a grave accent (`) in ``date '+%Y-%m-%d'.`.
Should be:
```
$ mysqldump -u root -p -R cloud > cloud-backup_`date '+%Y-%m-%d'`.sql
$ mysqldump -u root -p cloud_usage > cloud_usage-backup_`date '+%Y-%m-%d'`.sql
```