### PR TITLE
Fix endpointe typo

### DIFF
--- a/source/adminguide/locale/pot/networking/external_firewalls_and_load_balancers.pot
+++ b/source/adminguide/locale/pot/networking/external_firewalls_and_load_balancers.pot
@@ -503,12 +503,12 @@ msgstr ""
 
 #: ../../networking/external_firewalls_and_load_balancers.rst:456
 # 0ac0707e74464bd0840f60e335716a25
-msgid "Ensure that the endpointe.url parameter present in the Global Settings is set to the Management Server API URL. For example, ``http://10.102.102.22:8080/client/api``. In a multi-node Management Server deployment, use the virtual IP address configured in the load balancer for the management server's cluster. Additionally, ensure that the NetScaler device has access to this IP address to provide AutoScale support."
+msgid "Ensure that the endpoint.url parameter present in the Global Settings is set to the Management Server API URL. For example, ``http://10.102.102.22:8080/client/api``. In a multi-node Management Server deployment, use the virtual IP address configured in the load balancer for the management server's cluster. Additionally, ensure that the NetScaler device has access to this IP address to provide AutoScale support."
 msgstr ""
 
 #: ../../networking/external_firewalls_and_load_balancers.rst:464
 # f8d93cd584a54fd8b2a72143d4107323
-msgid "If you update the endpointe.url, disable the AutoScale functionality of the load balancer rules in the system, then enable them back to reflect the changes. For more information see :ref:`update-autoscale`."
+msgid "If you update the endpoint.url, disable the AutoScale functionality of the load balancer rules in the system, then enable them back to reflect the changes. For more information see :ref:`update-autoscale`."
 msgstr ""
 
 #: ../../networking/external_firewalls_and_load_balancers.rst:468

--- a/source/adminguide/locale/pot/networking2.pot
+++ b/source/adminguide/locale/pot/networking2.pot
@@ -2771,12 +2771,12 @@ msgstr ""
 
 #: ../../networking2.rst:2451
 # c4bb8c60d3214089b1726fe9bea68db1
-msgid "Ensure that the endpointe.url parameter present in the Global Settings is set to the Management Server API URL. For example, ``http://10.102.102.22:8080/client/api``. In a multi-node Management Server deployment, use the virtual IP address configured in the load balancer for the management server's cluster. Additionally, ensure that the NetScaler device has access to this IP address to provide AutoScale support."
+msgid "Ensure that the endpoint.url parameter present in the Global Settings is set to the Management Server API URL. For example, ``http://10.102.102.22:8080/client/api``. In a multi-node Management Server deployment, use the virtual IP address configured in the load balancer for the management server's cluster. Additionally, ensure that the NetScaler device has access to this IP address to provide AutoScale support."
 msgstr ""
 
 #: ../../networking2.rst:2459
 # f6027494d923450aa21e243d185af107
-msgid "If you update the endpointe.url, disable the AutoScale functionality of the load balancer rules in the system, then enable them back to reflect the changes. For more information see :ref:`update-autoscale`."
+msgid "If you update the endpoint.url, disable the AutoScale functionality of the load balancer rules in the system, then enable them back to reflect the changes. For more information see :ref:`update-autoscale`."
 msgstr ""
 
 #: ../../networking2.rst:2465

--- a/source/adminguide/locale/pot/networking_and_traffic.pot
+++ b/source/adminguide/locale/pot/networking_and_traffic.pot
@@ -2758,12 +2758,12 @@ msgstr ""
 
 #: ../../networking/external_firewalls_and_load_balancers.rst:456
 # d8cef4ea8860477489a80f3a715fbd90
-msgid "Ensure that the endpointe.url parameter present in the Global Settings is set to the Management Server API URL. For example, ``http://10.102.102.22:8080/client/api``. In a multi-node Management Server deployment, use the virtual IP address configured in the load balancer for the management server's cluster. Additionally, ensure that the NetScaler device has access to this IP address to provide AutoScale support."
+msgid "Ensure that the endpoint.url parameter present in the Global Settings is set to the Management Server API URL. For example, ``http://10.102.102.22:8080/client/api``. In a multi-node Management Server deployment, use the virtual IP address configured in the load balancer for the management server's cluster. Additionally, ensure that the NetScaler device has access to this IP address to provide AutoScale support."
 msgstr ""
 
 #: ../../networking/external_firewalls_and_load_balancers.rst:464
 # 1cd70adcb30d47abbcc3dc69e3707036
-msgid "If you update the endpointe.url, disable the AutoScale functionality of the load balancer rules in the system, then enable them back to reflect the changes. For more information see :ref:`update-autoscale`."
+msgid "If you update the endpoint.url, disable the AutoScale functionality of the load balancer rules in the system, then enable them back to reflect the changes. For more information see :ref:`update-autoscale`."
 msgstr ""
 
 #: ../../networking/external_firewalls_and_load_balancers.rst:468

--- a/source/adminguide/locale/zh_CN/LC_MESSAGES/networking/external_firewalls_and_load_balancers.po
+++ b/source/adminguide/locale/zh_CN/LC_MESSAGES/networking/external_firewalls_and_load_balancers.po
@@ -729,7 +729,7 @@ msgstr ""
 # 0ac0707e74464bd0840f60e335716a25
 #: ../../networking/external_firewalls_and_load_balancers.rst:456
 msgid ""
-"Ensure that the endpointe.url parameter present in the Global Settings is "
+"Ensure that the endpoint.url parameter present in the Global Settings is "
 "set to the Management Server API URL. For example, "
 "``http://10.102.102.22:8080/client/api``. In a multi-node Management Server "
 "deployment, use the virtual IP address configured in the load balancer for "
@@ -740,10 +740,10 @@ msgstr "确保在全局配置中的结束点地址参数已设置为管理服务
 # f8d93cd584a54fd8b2a72143d4107323
 #: ../../networking/external_firewalls_and_load_balancers.rst:464
 msgid ""
-"If you update the endpointe.url, disable the AutoScale functionality of the "
+"If you update the endpoint.url, disable the AutoScale functionality of the "
 "load balancer rules in the system, then enable them back to reflect the "
 "changes. For more information see :ref:`update-autoscale`."
-msgstr "如果更新了endpointe.url，在系统自动负载均衡器规则里，先关闭自缩放功能随后再开启，以应用此更新。。更多信息，参见 :ref:`update-autoscale`。"
+msgstr "如果更新了endpoint.url，在系统自动负载均衡器规则里，先关闭自缩放功能随后再开启，以应用此更新。。更多信息，参见 :ref:`update-autoscale`。"
 
 # f4e671d2a1814ee7936944319291f882
 #: ../../networking/external_firewalls_and_load_balancers.rst:468

--- a/source/adminguide/networking/external_firewalls_and_load_balancers.rst
+++ b/source/adminguide/networking/external_firewalls_and_load_balancers.rst
@@ -452,7 +452,7 @@ Before you configure an AutoScale rule, consider the following:
    <#configuring-snmp-community-string-on-a-rhel-server>`_
    to configure SNMP on a RHEL machine.
 
--  Ensure that the endpointe.url parameter present in the Global
+-  Ensure that the endpoint.url parameter present in the Global
    Settings is set to the Management Server API URL. For example,
    ``http://10.102.102.22:8080/client/api``. In a multi-node Management
    Server deployment, use the virtual IP address configured in the load
@@ -460,7 +460,7 @@ Before you configure an AutoScale rule, consider the following:
    that the NetScaler device has access to this IP address to provide
    AutoScale support.
 
-   If you update the endpointe.url, disable the AutoScale functionality
+   If you update the endpoint.url, disable the AutoScale functionality
    of the load balancer rules in the system, then enable them back to
    reflect the changes. For more information see :ref:`update-autoscale`.
 

--- a/source/installguide/locale/pot/managing_networks.pot
+++ b/source/installguide/locale/pot/managing_networks.pot
@@ -2761,12 +2761,12 @@ msgstr ""
 
 #: ../../managing_networks.rst:2392
 # 596a2d14b50c4e298970de7db5c4d19b
-msgid "Ensure that the endpointe.url parameter present in the Global Settings is set to the Management Server API URL. For example, http://10.102.102.22:8080/client/api. In a multi-node Management Server deployment, use the virtual IP address configured in the load balancer for the management server’s cluster. Additionally, ensure that the NetScaler device has access to this IP address to provide AutoScale support."
+msgid "Ensure that the endpoint.url parameter present in the Global Settings is set to the Management Server API URL. For example, http://10.102.102.22:8080/client/api. In a multi-node Management Server deployment, use the virtual IP address configured in the load balancer for the management server’s cluster. Additionally, ensure that the NetScaler device has access to this IP address to provide AutoScale support."
 msgstr ""
 
 #: ../../managing_networks.rst:2400
 # 59583fe0dfc14e2db8bcc23629da18e3
-msgid "If you update the endpointe.url, disable the AutoScale functionality of the load balancer rules in the system, then enable them back to reflect the changes. For more information see `Updating an AutoScale Configuration <#update-autoscale>`__"
+msgid "If you update the endpoint.url, disable the AutoScale functionality of the load balancer rules in the system, then enable them back to reflect the changes. For more information see `Updating an AutoScale Configuration <#update-autoscale>`__"
 msgstr ""
 
 #: ../../managing_networks.rst:2407


### PR DESCRIPTION
Updates documentation references of global settings parameter `endpointe.url` to `endpoint.url`.

This PR is related to https://github.com/apache/cloudstack/pull/5832 (already merged).