### PR TITLE
Add Ubuntu 22.04 in compatibility matrix

### DIFF
--- a/source/releasenotes/compat.rst
+++ b/source/releasenotes/compat.rst
@@ -22,7 +22,7 @@ Supported OS Versions for Management Server
 This section lists the operating systems that are supported for running
 CloudStack Management Server.
 
--  Ubuntu 18.04 LTS, 20.04 LTS
+-  Ubuntu 18.04 LTS, 20.04 LTS, 22.04 LTS
 -  CentOS versions 7
 -  Rocky Linux 8
 -  RHEL versions 7, 8
@@ -43,7 +43,7 @@ Supported Hypervisor Versions
 CloudStack supports three hypervisor families, XenServer with XAPI, KVM,
 and VMware with vSphere.
 
--  Ubuntu 18.04 LTS, 20.04 LTS with KVM
+-  Ubuntu 18.04 LTS, 20.04 LTS, 22.04 LTS with KVM
 -  CentOS 7 with KVM
 -  Rocky Linux 8 with KVM
 -  Red Hat Enterprise Linux 7, 8 with KVM


### PR DESCRIPTION
everything looks fine when deploy a cloudstack with ubuntu 22.04 as management server and hypervisor.
