### PR TITLE
Added notes to VPC and isolated network creations about SG enabled zones

### DIFF
--- a/source/adminguide/networking/advanced_zone_config.rst
+++ b/source/adminguide/networking/advanced_zone_config.rst
@@ -63,6 +63,9 @@ configure the base guest network:
 
 #. Click OK.
 
+.. note:: 
+   In security groups-enabled Advanced zones and Basic zones, creation of
+   VPC and isolated networks are not supported.
 
 Configure Public Traffic in an Advanced Zone
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/adminguide/networking/virtual_private_cloud_config.rst
+++ b/source/adminguide/networking/virtual_private_cloud_config.rst
@@ -212,6 +212,9 @@ addresses in the form of a Classless Inter-Domain Routing (CIDR) block.
 
 #. Click OK.
 
+.. note:: 
+   In security groups-enabled Advanced zones and Basic zones, creation of
+   VPC and isolated networks are not supported.
 
 Adding Tiers
 ~~~~~~~~~~~~


### PR DESCRIPTION
Added notes in VPC and isolated network creation forms saying 
"In security groups-enabled Advanced zones and Basic zones, creation of VPC and isolated networks are not supported."

This is related to an issue https://github.com/apache/cloudstack/issues/6453