### PR TITLE
Correct sudoers example

### DIFF
--- a/source/installguide/hypervisor/kvm.rst
+++ b/source/installguide/hypervisor/kvm.rst
@@ -209,7 +209,7 @@ sudoers file:
 .. parsed-literal::
 
    cloudstack ALL=NOPASSWD: /usr/bin/cloudstack-setup-agent
-   defaults:cloudstack !requiretty
+   Defaults:cloudstack !requiretty
 
 
 Configure CPU model for KVM guest (Optional)


### PR DESCRIPTION
`defaults` in sudoers is not valid, and so putting that in sudoers verbatim will cause sudo to fail. sudo expects the value to be `Defaults`, ie with a capital D.