### PR TITLE
added example to generate the kubernetes iso

### DIFF
--- a/source/plugins/cloudstack-kubernetes-service.rst
+++ b/source/plugins/cloudstack-kubernetes-service.rst
@@ -55,6 +55,16 @@ A script is provided (see below) to add other Kubernetes versions. Once an ISO i
 
 A script named create-kubernetes-binaries-iso.sh has been provided in the cloudstack-common package for creating a new setup ISO with the desired version of Kubernetes binaries and corresponding docker images.
 
+Eg: To generate the latest kubernetes iso
+
+.. parsed-literal::
+
+   1.27.2,  kubernetes version, see https://github.com/kubernetes/kubernetes/releases
+   1.3.0, CNI version, see https://github.com/containernetworking/plugins/releases
+   1.27.0, cri-tools version, see https://github.com/kubernetes-sigs/cri-tools/releases
+   1.11, weave addon for kubernetes, see https://github.com/weaveworks/weave/tree/master/prog/weave-kube
+   2.7.0, kubernetes dashboard version, see https://github.com/kubernetes/dashboard/release
+
 Usage:
 
 .. parsed-literal::
@@ -65,7 +75,7 @@ Eg:
 
 .. parsed-literal::
 
-   # ./create-kubernetes-binaries-iso.sh ./ 1.25.0 1.1.1 1.25.0 https://github.com/weaveworks/weave/releases/download/v2.8.1/weave-daemonset-k8s.yaml https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml setup-v1.25.0
+   # ./create-kubernetes-binaries-iso.sh ./ 1.27.2 1.3.0 1.27.0 https://raw.githubusercontent.com/weaveworks/weave/master/prog/weave-kube/weave-daemonset-k8s-1.11.yaml https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml setup-v1.27.2
 
 **NOTE:**
 From ACS 4.16 onwards, Kubernetes versions >= 1.20.x are only supported (https://endoflife.date/kubernetes).


### PR DESCRIPTION
updates the  documentation for the generation of Kubernetes iso which was useful in fixing https://github.com/apache/cloudstack/issues/7542