### PR TITLE
docs: Update instructions for adding DEB repository

### DIFF
--- a/source/installguide/hypervisor/kvm.rst
+++ b/source/installguide/hypervisor/kvm.rst
@@ -149,7 +149,7 @@ KVM instances.
 
       .. parsed-literal::
 
-         $ apt-get install chrony
+         $ apt install chrony
 
    In SUSE:
 
@@ -189,7 +189,7 @@ In Ubuntu:
 
 .. parsed-literal::
 
-   $ apt-get install cloudstack-agent
+   $ apt install cloudstack-agent
 
 In SUSE:
 

--- a/source/installguide/management-server/_database.rst
+++ b/source/installguide/management-server/_database.rst
@@ -47,7 +47,7 @@ MySQL. See :ref:`install-database-on-separate-node`.
 
    .. parsed-literal::
 
-      sudo apt-get install mysql-server
+      sudo apt install mysql-server
 
 #. Open the MySQL configuration file. The configuration file is
    ``/etc/my.cnf`` or ``/etc/mysql/my.cnf``, depending on your OS.
@@ -305,7 +305,7 @@ same node for MySQL. See `â€œInstall the Database on the Management Server Nodeâ
 
    .. parsed-literal::
 
-      sudo apt-get install mysql-server
+      sudo apt install mysql-server
 
 #. Edit the MySQL configuration (/etc/my.cnf or /etc/mysql/my.cnf,
    depending on your OS) and insert the following lines in the [mysqld]

--- a/source/installguide/management-server/_nfs.rst
+++ b/source/installguide/management-server/_nfs.rst
@@ -132,7 +132,7 @@ operating system version.
 
    .. parsed-literal::
 
-      apt-get install nfs-kernel-server
+      apt install nfs-kernel-server
 
 #. On the Management Server host, create two directories that you will
    use for primary and secondary storage. For example:

--- a/source/installguide/management-server/_pkg_install.rst
+++ b/source/installguide/management-server/_pkg_install.rst
@@ -51,5 +51,5 @@ Install on Ubuntu
 
 .. parsed-literal::
 
-   sudo apt-get install cloudstack-management
+   sudo apt install cloudstack-management
 

--- a/source/installguide/management-server/_pkg_repo.rst
+++ b/source/installguide/management-server/_pkg_repo.rst
@@ -99,19 +99,19 @@ repository to the file (replace "trusty" with "xenial" or "bionic" if it is the 
 
 .. parsed-literal::
 
-   deb http://download.cloudstack.org/ubuntu focal |version|
+   deb https://download.cloudstack.org/ubuntu focal |version|
 
 We now have to add the public key to the trusted keys.
 
 .. parsed-literal::
 
-   wget -O - http://download.cloudstack.org/release.asc |sudo apt-key add -
+   wget -O - https://download.cloudstack.org/release.asc |sudo tee /etc/apt/trusted.gpg.d/cloudstack.asc
 
 Now update your local apt cache.
 
 .. parsed-literal::
 
-   sudo apt-get update
+   sudo apt update
 
 Your DEB package repository should now be configured and ready for use.
 

--- a/source/installguide/management-server/_prerequisite.rst
+++ b/source/installguide/management-server/_prerequisite.rst
@@ -91,7 +91,7 @@ node.
 
       .. parsed-literal::
 
-         $ apt-get install chrony
+         $ apt install chrony
 
    In SUSE:
 

--- a/source/installguide/optional_installation.rst
+++ b/source/installguide/optional_installation.rst
@@ -62,7 +62,7 @@ Steps to Install the Usage Server
 
    .. parsed-literal::
       
-      # apt-get install cloudstack-usage
+      # apt install cloudstack-usage
 
 #. Once installed, start the Usage Server with the following command.
 


### PR DESCRIPTION
apt-key and apt-get are deprecated. This PR makes use of the proper commands