### PR TITLE
Add: Finding Primary storage for migration

### DIFF
--- a/source/adminguide/storage.rst
+++ b/source/adminguide/storage.rst
@@ -642,7 +642,8 @@ When you click on migrate volume, CloudStack lists the available primary
 storage.  CloudStack uses its storage pool allocators to identify the primary
 storages that are available and returns a list that is suitable for the selected
 volume's migration. 
-The list also could include primary storages that are mentioned as 'Not suitable'. The criteria for which the primary storages are not suitable are: 
+The list also could include primary storages that are mentioned as
+'Not suitable'. The criteria for which the primary storages are not suitable are: 
 	- Storage tag mismatch with the volume.
 	- Doesn't have enough capacity. 
 	- Reached its disable threshold

--- a/source/adminguide/storage.rst
+++ b/source/adminguide/storage.rst
@@ -644,11 +644,11 @@ storages that are available and returns a list that is suitable for the selected
 volume's migration. 
 The list also could include primary storages that are mentioned as
 'Not suitable'. The criteria for which the primary storages are not suitable are: 
-	- Storage tag mismatch with the volume.
-	- Doesn't have enough capacity. 
-	- Reached its disable threshold
-	- Disabled. 
-Mismatch in the type of storage such as shared /Local. 
+-  Storage tag mismatch with the volume.
+-  Doesn't have enough capacity. 
+-  Reached its disable threshold.
+-  Disabled.
+-  Mismatch in the type of storage such as shared /Local. 
 
 Resizing Volumes
 ~~~~~~~~~~~~~~~~

--- a/source/adminguide/storage.rst
+++ b/source/adminguide/storage.rst
@@ -638,7 +638,10 @@ be restarted.
 
 Finding Primary Storage for Migration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When you click on migrate volume, CloudStack lists the available primary storage.  CloudStack uses its storage pool allocators to identify the primary storages that are available and returns a list that is suitable for the selected volume's migration. 
+When you click on migrate volume, CloudStack lists the available primary
+storage.  CloudStack uses its storage pool allocators to identify the primary
+storages that are available and returns a list that is suitable for the selected
+volume's migration. 
 The list also could include primary storages that are mentioned as 'Not suitable'. The criteria for which the primary storages are not suitable are: 
 	- Storage tag mismatch with the volume.
 	- Doesn't have enough capacity. 

--- a/source/adminguide/storage.rst
+++ b/source/adminguide/storage.rst
@@ -636,6 +636,15 @@ be restarted.
       Instance's root disk is allowed from one PowerFlex/ScaleIO storage pool
       to another, without stopping the Instance.
 
+Finding Primary Storage for Migration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When you click on migrate volume, CloudStack lists the available primary storage.  CloudStack uses its storage pool allocators to identify the primary storages that are available and returns a list that is suitable for the selected volume's migration. 
+The list also could include primary storages that are mentioned as 'Not suitable'. The criteria for which the primary storages are not suitable are: 
+	- Storage tag mismatch with the volume.
+	- Doesn't have enough capacity. 
+	- Reached its disable threshold
+	- Disabled. 
+Mismatch in the type of storage such as shared /Local. 
 
 Resizing Volumes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Adding a section describing how cloudstack finds a suitable primary storage for migration. 

<!-- readthedocs-preview cloudstack-documentation start -->
----
:books: Documentation preview :books:: https://cloudstack-documentation--325.org.readthedocs.build/en/325/

<!-- readthedocs-preview cloudstack-documentation end -->