### PR TITLE
Add `sphinx` and `sphinx-intl` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 docutils<0.18
+sphinx
+sphinx-intl


### PR DESCRIPTION
You will need to have `sphinx` and `sphinx-intl` installed to run the make commands successfully

