### PR TITLE
build: use sphinx 1.8.6 instead of latest 8.2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 docutils<0.18
+sphinx<2
+sphinx-rtd-theme<0.5
+readthedocs-sphinx-ext<2.3
+jinja2<3.1.0


### PR DESCRIPTION
Tested on readthedocs.org, the build succeeded and has been published at
https://docs.cloudstack.apache.org/en/minor-doc-update/

Please note, this is a workaround. We need to support more recent sphinx and docutils versions