### PR TITLE
Add github action to generate docs preview on PRs

### DIFF
--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -1,0 +1,15 @@
+name: readthedocs/actions
+
+on:
+  pull_request_target:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  pull-request-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "cloudstack-documentation"


### PR DESCRIPTION
This PR adds a github action to generate docs on PRs. This requires adding a webhook configuration for readthedocs on the repo.

@DaanHoogland has asked ASF Infra to update the webhook configuration for the repo. This should work once the webhook starts working.