### PR TITLE
Update IPv6 Support page to remove explanation of what an IPv6 address is from introduction

### DIFF
--- a/source/plugins/ipv6.rst
+++ b/source/plugins/ipv6.rst
@@ -22,7 +22,7 @@ version of the Internet Protocol (IP) that defines routing the network
 traffic. IPv6 uses a 128-bit address that exponentially expands the
 current address space that is available to the users. IPv6 addresses
 consist of eight groups of four hexadecimal digits separated by colons,
-for example, 5001:0dt8:83a3:1012:1000:8s2e:0870:7454. CloudStack
+for example, 2001:0db8:83a3:1012:1000:8b2e:0870:7454. CloudStack
 supports IPv6 for shared and isolated networks. It also supports IPv6 for VPC Network Tiers.
 
 Shared network

--- a/source/plugins/ipv6.rst
+++ b/source/plugins/ipv6.rst
@@ -16,14 +16,7 @@
 
 IPv6 Support in CloudStack
 ===========================
-
-CloudStack supports Internet Protocol version 6 (IPv6), the recent
-version of the Internet Protocol (IP) that defines routing the network
-traffic. IPv6 uses a 128-bit address that exponentially expands the
-current address space that is available to the users. IPv6 addresses
-consist of eight groups of four hexadecimal digits separated by colons,
-for example, 2001:0db8:83a3:1012:1000:8b2e:0870:7454. CloudStack
-supports IPv6 for shared and isolated networks. It also supports IPv6 for VPC Network Tiers.
+CloudStack supports IPv6 for shared and isolated networks. It also supports IPv6 for VPC Network Tiers.
 
 Shared network
 --------------

--- a/source/plugins/ipv6.rst
+++ b/source/plugins/ipv6.rst
@@ -16,7 +16,7 @@
 
 IPv6 Support in CloudStack
 ===========================
-CloudStack supports IPv6 for shared and isolated networks. It also supports IPv6 for VPC Network Tiers.
+CloudStack has limited IPv6 support. It supports IPv6 for shared and isolated networks. It also supports IPv6 for VPC Network Tiers.
 
 Shared network
 --------------


### PR DESCRIPTION
The characters `s` and `t` are not valid hex. 
Correct the example `5001:0dt8:83a3:1012:1000:8s2e:0870:7454` so that it is a valid IPv6 address. 
Also change to use the 2001:db8::/32 [IPv6 documentation prefix](https://www.rfc-editor.org/rfc/rfc3849.html).

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--370.org.readthedocs.build/en/370/

<!-- readthedocs-preview cloudstack-documentation end -->