### PR TITLE
Fix RTD builds: Update requirements.txt with the latest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-docutils<0.18
-sphinx<2
-sphinx-rtd-theme<0.5
-readthedocs-sphinx-ext<2.3
-jinja2<3.1.0
+docutils==0.20.1
+Sphinx==7.2.6
+sphinx-rtd-theme==2.0.0
+readthedocs-sphinx-ext==2.2.5
+Jinja2==3.1.3


### PR DESCRIPTION
 This PR upgrades the packages to the latest version. Build has stopped working on readthedocs because of older version of packages because of the below error:

```
 Running Sphinx v1.8.6
loading translations [en]... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudstack-documentation/envs/374/lib/python3.11/site-packages/sphinx/registry.py", line 483, in load_extension
    metadata = mod.setup(app)
               ^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudstack-documentation/envs/374/lib/python3.11/site-packages/alabaster/__init__.py", line 31, in setup
    app.require_sphinx("3.4")
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudstack-documentation/envs/374/lib/python3.11/site-packages/sphinx/application.py", line 462, in require_sphinx
    raise VersionRequirementError(version)
sphinx.errors.VersionRequirementError: 3.4

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudstack-documentation/envs/374/lib/python3.11/site-packages/sphinx/cmd/build.py", line 300, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudstack-documentation/envs/374/lib/python3.11/site-packages/sphinx/application.py", line 224, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudstack-documentation/envs/374/lib/python3.11/site-packages/sphinx/application.py", line 449, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cloudstack-documentation/envs/374/lib/python3.11/site-packages/sphinx/registry.py", line 486, in load_extension
    raise VersionRequirementError(
sphinx.errors.VersionRequirementError: The alabaster extension used by this project needs at least Sphinx v3.4; it therefore cannot be built with this version.

Sphinx version error:
The alabaster extension used by this project needs at least Sphinx v3.4; it therefore cannot be built with this version. 
```

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--375.org.readthedocs.build/en/375/

<!-- readthedocs-preview cloudstack-documentation end -->