### PR TITLE
Adding --> Add for the object storage

### DIFF
--- a/source/installguide/configuration.rst
+++ b/source/installguide/configuration.rst
@@ -1701,7 +1701,7 @@ zone:
    -  Path. The path to the zone's Secondary Staging Store.
 
 
-Adding Object Storage
+Add Object Storage
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can add  object storage pools at any time to add more capacity or providers to CloudStack


### PR DESCRIPTION
Link inside the ACS UI points to:

http://docs.cloudstack.apache.org/en/latest/installguide/configuration.html#add-object-storage

i.e. use word "add" not "adding" - easier to fix docs than the UI.

![image](https://github.com/apache/cloudstack-documentation/assets/45762285/7391c278-6933-41fb-a0a1-cc249e249e66)


<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--389.org.readthedocs.build/en/389/

<!-- readthedocs-preview cloudstack-documentation end -->