### PR TITLE
Correct desc on the "forced" parameter during VM import

### DIFF
--- a/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
+++ b/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
@@ -148,7 +148,7 @@ importUnmanagedInstance API
    - **migrateallowed** (Instance and its volumes are allowed to migrate to different host/storage pool when offering tags conflict with host/storage pool)
    - **forced** (If true, an Instance is imported despite some of its NIC's MAC addresses being already present)
 
-.. note:: The `forced` parameter is false by default and thus prevents importing an Instance which has a NIC containing a MAC address that has been previously assigned by CloudStack to another existing VM. If it is set to true, importing a VM with such already-used MAC addresses of the NICS will be allowed. This should be done with a full understanding of possible consequences due to duplicate MAC addresses.
+.. note:: The `forced` parameter is false by default and thus prevents importing an Instance which has a NIC containing a MAC address that has been previously assigned by CloudStack to another existing VM. If it is set to true, importing a VM with such already-used MAC addresses of the NICS will be allowed, however, the original MAC address will be replaced with a newly generated MAC address.
 
 **Response**:
 
@@ -498,7 +498,7 @@ choose the temporary storage location on the external host for the converted fil
    - **details** (Map for Instance details)
    - **forced** (If true, an Instance is imported despite some of its NIC's MAC addresses being already present)
 
-.. note:: The `forced` parameter is false by default and thus prevents importing an Instance which has a NIC containing a MAC address that has been previously assigned by CloudStack to another existing VM. If it is set to true, importing a VM with such already-used MAC addresses of the NICS will be allowed. This should be done with a full understanding of possible consequences due to duplicate MAC addresses.
+.. note:: The `forced` parameter is false by default and thus prevents importing an Instance which has a NIC containing a MAC address that has been previously assigned by CloudStack to another existing VM. If it is set to true, importing a VM with such already-used MAC addresses of the NICS will be allowed, however, the original MAC address will be replaced with a newly generated MAC address.
 
 **Response**:
 


### PR DESCRIPTION
Correct desc on the "forced" parameter during VM import

cc @nvazquez for confirmation of the changes., pls, since, afaik, we don't allow duplicate MAC addresses, thus the original description is not valid.