### PR TITLE
source: add support for Ubuntu 24.04 as both mgmt server and KVM host

### DIFF
--- a/source/releasenotes/compat.rst
+++ b/source/releasenotes/compat.rst
@@ -22,7 +22,7 @@ Supported OS Versions for Management Server
 This section lists the operating systems that are supported for running
 CloudStack Management Server.
 
--  Ubuntu 18.04 LTS, 20.04 LTS, 22.04 LTS
+-  Ubuntu 20.04 LTS, 22.04 LTS, 24.04 LTS
 -  CentOS versions 7
 -  Rocky Linux 8, 9
 -  Alma Linux 8, 9
@@ -45,7 +45,7 @@ Supported Hypervisor Versions
 CloudStack supports three hypervisor families, XenServer with XAPI, KVM,
 and VMware with vSphere.
 
--  Ubuntu 18.04 LTS, 20.04 LTS, 22.04 LTS with KVM
+-  Ubuntu 20.04 LTS, 22.04 LTS, 24.04 LTS with KVM
 -  CentOS 7 with KVM
 -  Rocky Linux 8, 9 with KVM
 -  Red Hat Enterprise Linux 7, 8, 9 with KVM


### PR DESCRIPTION
Adds 24.04 and removed 18.04 (eol'd last year)