### PR TITLE
Update doc with new database encryptor

### DIFF
--- a/source/adminguide/hosts.rst
+++ b/source/adminguide/hosts.rst
@@ -244,11 +244,10 @@ To change a Node's password:
 
    .. code:: bash
 
-      java -classpath /usr/share/cloudstack-common/lib/jasypt-1.9.0.jar \
-      org.jasypt.intf.cli.JasyptPBEStringEncryptionCLI \
-      encrypt.sh input="newrootpassword" \
-      password="databasekey" \
-      verbose=false
+      java -classpath /usr/share/cloudstack-common/lib/cloudstack-utils.jar \
+      com.cloud.utils.crypt.EncryptionCLI \
+      -p databasekey \
+      -i newrootpassword
 
 #. Get the list of host IDs for the host in the cluster where you are
    changing the password. You will need to access the database to

--- a/source/adminguide/management.rst
+++ b/source/adminguide/management.rst
@@ -181,7 +181,7 @@ add the encrypted password to
 
    .. code:: bash
 
-           # java -classpath /usr/share/cloudstack-common/lib/jasypt-1.9.2.jar \ org.jasypt.intf.cli.JasyptPBEStringEncryptionCLI encrypt.sh \ input="newpassword123" password="`cat /etc/cloudstack/management/key`" \ verbose=false
+           # java -classpath /usr/share/cloudstack-common/lib/cloudstack-utils.jar com.cloud.utils.crypt.EncryptionCLI -p `cat /etc/cloudstack/management/key` -i newpassword123
 
 
 File encryption type


### PR DESCRIPTION
The database encryptor was updated in the release 4.18.0 (PR here: https://github.com/apache/cloudstack/pull/7003).

Ref: https://cwiki.apache.org/confluence/display/CLOUDSTACK/New+database+encryption+cipher+-+AeadBase64Encryptor


<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--414.org.readthedocs.build/en/414/

<!-- readthedocs-preview cloudstack-documentation end -->