### PR TITLE
Fix typo XVLAN

### DIFF
--- a/source/plugins/vxlan.rst
+++ b/source/plugins/vxlan.rst
@@ -321,7 +321,7 @@ you would change the configuration similar to below.
        bridge_maxwait 1
 
 
-Configure iptables to pass XVLAN packets
+Configure iptables to pass VXLAN packets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Since VXLAN uses UDP packet to forward encapsulated the L2 frames,


### PR DESCRIPTION
Fix typo XVLAN

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--427.org.readthedocs.build/en/427/

<!-- readthedocs-preview cloudstack-documentation end -->