### PR TITLE
fixed incorrect apt-get invocation in upgrade manuals

### DIFF
--- a/source/upgrading/upgrade/upgrade-4.10.rst
+++ b/source/upgrading/upgrade/upgrade-4.10.rst
@@ -171,13 +171,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel410:
@@ -362,7 +362,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a
     line that reads:

--- a/source/upgrading/upgrade/upgrade-4.11.rst
+++ b/source/upgrading/upgrade/upgrade-4.11.rst
@@ -164,13 +164,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel411:
@@ -284,7 +284,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.12.rst
+++ b/source/upgrading/upgrade/upgrade-4.12.rst
@@ -163,13 +163,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel412:
@@ -285,7 +285,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.13.rst
+++ b/source/upgrading/upgrade/upgrade-4.13.rst
@@ -155,13 +155,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel413:
@@ -263,7 +263,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.14.rst
+++ b/source/upgrading/upgrade/upgrade-4.14.rst
@@ -149,13 +149,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel414:
@@ -257,7 +257,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.15.rst
+++ b/source/upgrading/upgrade/upgrade-4.15.rst
@@ -150,13 +150,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel414:
@@ -258,7 +258,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.16.rst
+++ b/source/upgrading/upgrade/upgrade-4.16.rst
@@ -150,13 +150,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel414:
@@ -258,7 +258,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.17.rst
+++ b/source/upgrading/upgrade/upgrade-4.17.rst
@@ -145,13 +145,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel414:
@@ -253,7 +253,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.18.rst
+++ b/source/upgrading/upgrade/upgrade-4.18.rst
@@ -145,13 +145,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel414:
@@ -253,7 +253,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.19.rst
+++ b/source/upgrading/upgrade/upgrade-4.19.rst
@@ -147,13 +147,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel414:
@@ -255,7 +255,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.2.rst
+++ b/source/upgrading/upgrade/upgrade-4.2.rst
@@ -149,13 +149,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel42:
@@ -343,7 +343,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
    line that reads:

--- a/source/upgrading/upgrade/upgrade-4.3.rst
+++ b/source/upgrading/upgrade/upgrade-4.3.rst
@@ -154,13 +154,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel43:
@@ -348,7 +348,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
    line that reads:

--- a/source/upgrading/upgrade/upgrade-4.4.rst
+++ b/source/upgrading/upgrade/upgrade-4.4.rst
@@ -154,13 +154,13 @@ CloudStack apt repository
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
     .. parsed-literal::
 
-        $ sudo apt-get upgrade cloudstack-usage
+        $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel44:
@@ -351,7 +351,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
     line that reads:

--- a/source/upgrading/upgrade/upgrade-4.5.rst
+++ b/source/upgrading/upgrade/upgrade-4.5.rst
@@ -166,13 +166,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel45:
@@ -362,7 +362,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
     line that reads:

--- a/source/upgrading/upgrade/upgrade-4.6.rst
+++ b/source/upgrading/upgrade/upgrade-4.6.rst
@@ -152,13 +152,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel46:
@@ -348,7 +348,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
     line that reads:

--- a/source/upgrading/upgrade/upgrade-4.7.rst
+++ b/source/upgrading/upgrade/upgrade-4.7.rst
@@ -151,13 +151,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel47:
@@ -345,7 +345,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
     line that reads:

--- a/source/upgrading/upgrade/upgrade-4.8.rst
+++ b/source/upgrading/upgrade/upgrade-4.8.rst
@@ -152,13 +152,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel48:
@@ -348,7 +348,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
     line that reads:

--- a/source/upgrading/upgrade/upgrade-4.9.rst
+++ b/source/upgrading/upgrade/upgrade-4.9.rst
@@ -165,13 +165,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel49:
@@ -356,7 +356,7 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a
     line that reads:


### PR DESCRIPTION
In upgrade manuals, in all debian/ubuntu examples there is incorrect apt-get command used.
`apt-get upgrade` by itself does not requires any parameters.
Upgrade of particular package is done by `apt-get install package-name`

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--428.org.readthedocs.build/en/428/

<!-- readthedocs-preview cloudstack-documentation end -->