### PR TITLE
Update Cloudian Integration plugin for newer HyperStore versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ On your computer, follow these steps to setup a local repository for working on 
 .. code:: bash
 
    $ git clone https://github.com/YOUR_ACCOUNT/cloudstack-documentation.git
-   $ cd cloudstack-docs-install
+   $ cd cloudstack-documentation
    $ git remote add upstream https://github.com/apache/cloudstack-documentation.git
    $ git checkout main
    $ git fetch upstream

--- a/source/plugins/cloudian-connector.rst
+++ b/source/plugins/cloudian-connector.rst
@@ -156,7 +156,15 @@ Cloudian ships with SSO disabled by default. You will need to enable it on each
 CMC server. Additionally, you will need to choose a unique SSO shared key that
 you will also configure in the CloudStack connector further below.
 
-Edit Puppet config to enable SSO on all CMC servers:
+HyperStore 8+ instructions to enable SSO on all CMC servers:
+
+   ::
+
+     # hsctl config set cmc.sso.enabled=true
+     # hsctl config set cmc.sso.sharedKey=YourSecretKeyHere
+     # hsctl config apply cmc
+
+Older HyperStore versions use Puppet. Edit Puppet config to enable SSO on all CMC servers:
 
    ::
 


### PR DESCRIPTION
- Fix a small typo in the main README.rst document
- HyperStore version 8 onwards uses a command to configure system settings instead and no longer makes use of Puppet. Update the instructions for users configuring the connector against newer versions of HyperStore.

NOTES:
* If there is a better way to format this documentation change please let me know.
* I'm not sure how to build documentation to ensure this looks ok.

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--434.org.readthedocs.build/en/434/

<!-- readthedocs-preview cloudstack-documentation end -->