### PR TITLE
Ubuntu: fix apt-get usage

### DIFF
--- a/source/upgrading/upgrade/upgrade-4.10.rst
+++ b/source/upgrading/upgrade/upgrade-4.10.rst
@@ -171,13 +171,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel410:
@@ -362,7 +362,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a
     line that reads:

--- a/source/upgrading/upgrade/upgrade-4.11.rst
+++ b/source/upgrading/upgrade/upgrade-4.11.rst
@@ -164,13 +164,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel411:
@@ -284,7 +284,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.12.rst
+++ b/source/upgrading/upgrade/upgrade-4.12.rst
@@ -163,13 +163,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel412:
@@ -285,7 +285,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.13.rst
+++ b/source/upgrading/upgrade/upgrade-4.13.rst
@@ -155,13 +155,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel413:
@@ -263,7 +263,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.14.rst
+++ b/source/upgrading/upgrade/upgrade-4.14.rst
@@ -149,13 +149,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel414:
@@ -257,7 +257,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.15.rst
+++ b/source/upgrading/upgrade/upgrade-4.15.rst
@@ -150,13 +150,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel414:
@@ -258,7 +258,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.16.rst
+++ b/source/upgrading/upgrade/upgrade-4.16.rst
@@ -150,13 +150,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel414:
@@ -258,7 +258,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.17.rst
+++ b/source/upgrading/upgrade/upgrade-4.17.rst
@@ -145,13 +145,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel414:
@@ -253,7 +253,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.18.rst
+++ b/source/upgrading/upgrade/upgrade-4.18.rst
@@ -145,13 +145,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel414:
@@ -253,7 +253,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.19.rst
+++ b/source/upgrading/upgrade/upgrade-4.19.rst
@@ -147,13 +147,13 @@ Setup the public key for the above repository:
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel414:
@@ -255,7 +255,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Start the agent.
 

--- a/source/upgrading/upgrade/upgrade-4.2.rst
+++ b/source/upgrading/upgrade/upgrade-4.2.rst
@@ -149,13 +149,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel42:
@@ -343,7 +343,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
    line that reads:

--- a/source/upgrading/upgrade/upgrade-4.3.rst
+++ b/source/upgrading/upgrade/upgrade-4.3.rst
@@ -154,13 +154,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel43:
@@ -348,7 +348,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
    line that reads:

--- a/source/upgrading/upgrade/upgrade-4.4.rst
+++ b/source/upgrading/upgrade/upgrade-4.4.rst
@@ -154,13 +154,13 @@ CloudStack apt repository
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
     .. parsed-literal::
 
-        $ sudo apt-get upgrade cloudstack-usage
+        $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel44:
@@ -351,7 +351,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
     line that reads:

--- a/source/upgrading/upgrade/upgrade-4.5.rst
+++ b/source/upgrading/upgrade/upgrade-4.5.rst
@@ -166,13 +166,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel45:
@@ -362,7 +362,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
     line that reads:

--- a/source/upgrading/upgrade/upgrade-4.6.rst
+++ b/source/upgrading/upgrade/upgrade-4.6.rst
@@ -152,13 +152,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel46:
@@ -348,7 +348,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
     line that reads:

--- a/source/upgrading/upgrade/upgrade-4.7.rst
+++ b/source/upgrading/upgrade/upgrade-4.7.rst
@@ -151,13 +151,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel47:
@@ -345,7 +345,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
     line that reads:

--- a/source/upgrading/upgrade/upgrade-4.8.rst
+++ b/source/upgrading/upgrade/upgrade-4.8.rst
@@ -152,13 +152,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel48:
@@ -348,7 +348,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a 
     line that reads:

--- a/source/upgrading/upgrade/upgrade-4.9.rst
+++ b/source/upgrading/upgrade/upgrade-4.9.rst
@@ -165,13 +165,13 @@ read as appropriate for your |version| repository.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-management
+      $ sudo apt-get install cloudstack-management
 
 #. If you use CloudStack usage server
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-usage
+      $ sudo apt-get install cloudstack-usage
 
 
 .. _rhel49:
@@ -356,7 +356,8 @@ hosts.
 
    .. parsed-literal::
 
-      $ sudo apt-get upgrade cloudstack-agent
+      $ sudo apt-get update
+      $ sudo apt-get install cloudstack-agent
 
 #. Verify that the file ``/etc/cloudstack/agent/environment.properties`` has a
     line that reads:


### PR DESCRIPTION
"apt-get upgrade" does not parse any parameters, and just updates all packages that can be upgraded. As this does not seem to be the intended result, all usages of "apt-get" upgrade are modified to update only the requested package.

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--436.org.readthedocs.build/en/436/

<!-- readthedocs-preview cloudstack-documentation end -->