### PR TITLE
Global settings to prepend VPC name to Tier name

### DIFF
--- a/source/adminguide/networking/virtual_private_cloud_config.rst
+++ b/source/adminguide/networking/virtual_private_cloud_config.rst
@@ -266,6 +266,10 @@ other Network Tiers within the VPC.
 
    -  **Name**: A unique name for the Network Tier you create.
 
+   .. note::
+      Admins can choose to automatically prepend the VPC name to the Tier name during creation
+      using global configurations "vpc.tier.name.prepend" and "vpc.tier.name.prepend.delimiter".
+
    -  **Network Offering**: The following default Network offerings are
       listed: Internal LB,
       DefaultIsolatedNetworkOfferingForVpcNetworksNoLB,


### PR DESCRIPTION
Doc PR for https://github.com/apache/cloudstack/pull/9780

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--445.org.readthedocs.build/en/445/

<!-- readthedocs-preview cloudstack-documentation end -->