### PR TITLE
Rename Scheduled Snapshot to Recurring Snapshot

### DIFF
--- a/source/adminguide/locale/pot/storage.pot
+++ b/source/adminguide/locale/pot/storage.pot
@@ -1011,7 +1011,7 @@ msgstr ""
 
 #: ../../storage.rst:685
 # bc81c587ad8b4032b27d61690390e258
-msgid "With each snapshot schedule, users can also specify the number of recurring snapshots to be retained. Older snapshots that exceed the retention limit are automatically deleted. This user-defined limit must be equal to or lower than the global limit set by the CloudStack administrator. See `“Globally Configured Limits” <usage.html#globally-configured-limits>`_. The limit applies only to those snapshots that are taken as part of an automatic recurring snapshot policy. Additional manual snapshots can be created and retained."
+msgid "With each reccurring snapshot schedule, users can also specify the number of recurring snapshots to be retained. Older snapshots that exceed the retention limit are automatically deleted. This user-defined limit must be equal to or lower than the global limit set by the CloudStack administrator. See `“Globally Configured Limits” <usage.html#globally-configured-limits>`_. The limit applies only to those snapshots that are taken as part of an automatic recurring snapshot policy. Additional manual snapshots can be created and retained."
 msgstr ""
 
 #: ../../storage.rst:697

--- a/source/adminguide/locale/pot/storage.pot
+++ b/source/adminguide/locale/pot/storage.pot
@@ -1011,7 +1011,7 @@ msgstr ""
 
 #: ../../storage.rst:685
 # bc81c587ad8b4032b27d61690390e258
-msgid "With each snapshot schedule, users can also specify the number of scheduled snapshots to be retained. Older snapshots that exceed the retention limit are automatically deleted. This user-defined limit must be equal to or lower than the global limit set by the CloudStack administrator. See `“Globally Configured Limits” <usage.html#globally-configured-limits>`_. The limit applies only to those snapshots that are taken as part of an automatic recurring snapshot policy. Additional manual snapshots can be created and retained."
+msgid "With each snapshot schedule, users can also specify the number of recurring snapshots to be retained. Older snapshots that exceed the retention limit are automatically deleted. This user-defined limit must be equal to or lower than the global limit set by the CloudStack administrator. See `“Globally Configured Limits” <usage.html#globally-configured-limits>`_. The limit applies only to those snapshots that are taken as part of an automatic recurring snapshot policy. Additional manual snapshots can be created and retained."
 msgstr ""
 
 #: ../../storage.rst:697

--- a/source/adminguide/storage.rst
+++ b/source/adminguide/storage.rst
@@ -1305,7 +1305,7 @@ policy can be set up per disk volume. For example, a user can set up a
 daily Snapshot at 02:30.
 
 With each Snapshot schedule, users can also specify the number of
-scheduled Snapshots to be retained. Older Snapshots that exceed the
+recurring Snapshots to be retained. Older Snapshots that exceed the
 retention limit are automatically deleted. This user-defined limit must
 be equal to or lower than the global limit set by the CloudStack
 administrator. See `“Globally Configured


### PR DESCRIPTION
This is related to changes proposed in https://github.com/apache/cloudstack/pull/9773

Recurring Snapshot is the name used at most places in code and documentation apart from 1-2 places where the word Scheduled Snapsthot is used.
For the sake of consistency, rename all to Recurring Snapshots.

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--448.org.readthedocs.build/en/448/

<!-- readthedocs-preview cloudstack-documentation end -->