### PR TITLE
Fix command of nfs test mount missing mountpoint argument

### DIFF
--- a/source/installguide/management-server/_nfs.rst
+++ b/source/installguide/management-server/_nfs.rst
@@ -253,8 +253,8 @@ operating system version.
       .. parsed-literal::
 
          mkdir /primary
-         mount -t nfs <management-server-name>:/export/primary
+         mount -t nfs <management-server-name>:/export/primary /primary
          umount /primary
          mkdir /secondary
-         mount -t nfs <management-server-name>:/export/secondary
+         mount -t nfs <management-server-name>:/export/secondary /secondary
          umount /secondary


### PR DESCRIPTION
The command to mount the nfs shares to the filesystem is missing the directory where the nfs share should be mounted to.

Manpage `MOUNT(8)`
`mount [-t <fstype>] device mountpoint`

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--459.org.readthedocs.build/en/459/

<!-- readthedocs-preview cloudstack-documentation end -->