### PR TITLE
Added command to set libvirtd to traditional mode

### DIFF
--- a/source/adminguide/networking/virtual_private_cloud_config.rst
+++ b/source/adminguide/networking/virtual_private_cloud_config.rst
@@ -266,6 +266,10 @@ other Network Tiers within the VPC.
 
    -  **Name**: A unique name for the Network Tier you create.
 
+   .. note::
+      Admins can choose to automatically prepend the VPC name to the Tier name during creation
+      using global configurations "vpc.tier.name.prepend" and "vpc.tier.name.prepend.delimiter".
+
    -  **Network Offering**: The following default Network offerings are
       listed: Internal LB,
       DefaultIsolatedNetworkOfferingForVpcNetworksNoLB,

--- a/source/installguide/hypervisor/kvm.rst
+++ b/source/installguide/hypervisor/kvm.rst
@@ -478,6 +478,12 @@ cloudstack-agent and should already be installed.
    .. parsed-literal::
       remote_mode="legacy"
 
+   Set libvirtd mode to traditional mode (see https://libvirt.org/manpages/libvirtd.html#system-socket-activation):
+   
+   .. parsed-literal::
+      systemctl mask libvirtd.socket libvirtd-ro.socket \
+         libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
+
 
 #. Restart libvirt
 

--- a/source/installguide/hypervisor/kvm.rst
+++ b/source/installguide/hypervisor/kvm.rst
@@ -478,11 +478,11 @@ cloudstack-agent and should already be installed.
    .. parsed-literal::
       remote_mode="legacy"
 
-   Set libvirtd mode to traditional mode (see https://libvirt.org/manpages/libvirtd.html#system-socket-activation):
-   
+   On Ubuntu 24.04 or newer set libvirtd mode to traditional mode (see https://libvirt.org/manpages/libvirtd.html#system-socket-activation):
+
    .. parsed-literal::
-      systemctl mask libvirtd.socket libvirtd-ro.socket \
-         libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
+
+      systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
 
 
 #. Restart libvirt


### PR DESCRIPTION
If on Ubuntu 24.04, following the guide you get this error when restarting libvirtd:

```
systemd[1]: Failed to start libvirtd.service - libvirt legacy monolithic daemon.
```

Here is explained to set libvirtd to traditional mode to use the `--listen` flag: https://libvirt.org/manpages/libvirtd.html#system-socket-activation

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--462.org.readthedocs.build/en/462/

<!-- readthedocs-preview cloudstack-documentation end -->