### PR TITLE
vxlan prefix must be given to prevent interpretation as vlan

### DIFF
--- a/source/adminguide/networking/multiple_subnets_in_shared_network.rst
+++ b/source/adminguide/networking/multiple_subnets_in_shared_network.rst
@@ -95,8 +95,7 @@ Adding Multiple Subnets to a Shared Network
       defaulted to the vlan of the network or if vlan of the network is
       null - to Untagged
 
-      .. NOTE if the VNI is of a VXLAN, the protocol prefix `vxlan://`
-         must be used, like in `vxlan://<vni>`
+.. note:: If the VNI is of a VXLAN, the protocol prefix `vxlan://` must be used, like in `vxlan://<vni>`
 
 #. Click OK.
 

--- a/source/adminguide/networking/multiple_subnets_in_shared_network.rst
+++ b/source/adminguide/networking/multiple_subnets_in_shared_network.rst
@@ -95,6 +95,9 @@ Adding Multiple Subnets to a Shared Network
       defaulted to the vlan of the network or if vlan of the network is
       null - to Untagged
 
+      .. NOTE if the VNI is of a VXLan, the potocol prefix `vxlan://`
+         must be used, like in `vxlan://<vni>`
+
 #. Click OK.
 
 

--- a/source/adminguide/networking/multiple_subnets_in_shared_network.rst
+++ b/source/adminguide/networking/multiple_subnets_in_shared_network.rst
@@ -95,7 +95,7 @@ Adding Multiple Subnets to a Shared Network
       defaulted to the vlan of the network or if vlan of the network is
       null - to Untagged
 
-      .. NOTE if the VNI is of a VXLan, the potocol prefix `vxlan://`
+      .. NOTE if the VNI is of a VXLAN, the protocol prefix `vxlan://`
          must be used, like in `vxlan://<vni>`
 
 #. Click OK.

--- a/source/installguide/configuration.rst
+++ b/source/installguide/configuration.rst
@@ -637,6 +637,9 @@ Core Zone
 
    -  **VLAN / VNI ID.** The VLAN / VNI ID's that will be used for guest traffic.
 
+            .. NOTE if the VNI is of a VXLan, the potocol prefix
+               `vxlan://` must be used, like in `vxlan://<vni>`
+
 #. In a new pod, CloudStack adds the first cluster for you. You can
    always add more clusters later. For an overview of what a cluster is,
    see :ref:`about-clusters`

--- a/source/installguide/configuration.rst
+++ b/source/installguide/configuration.rst
@@ -637,8 +637,7 @@ Core Zone
 
    -  **VLAN / VNI ID.** The VLAN / VNI ID's that will be used for guest traffic.
 
-            .. NOTE if the VNI is of a VXLAN, the protocol prefix
-               `vxlan://` must be used, like in `vxlan://<vni>`
+.. note:: If the VNI is of a VXLAN, the protocol prefix `vxlan://` must be used, like in `vxlan://<vni>`
 
 #. In a new pod, CloudStack adds the first cluster for you. You can
    always add more clusters later. For an overview of what a cluster is,

--- a/source/installguide/configuration.rst
+++ b/source/installguide/configuration.rst
@@ -637,7 +637,7 @@ Core Zone
 
    -  **VLAN / VNI ID.** The VLAN / VNI ID's that will be used for guest traffic.
 
-            .. NOTE if the VNI is of a VXLan, the potocol prefix
+            .. NOTE if the VNI is of a VXLAN, the protocol prefix
                `vxlan://` must be used, like in `vxlan://<vni>`
 
 #. In a new pod, CloudStack adds the first cluster for you. You can


### PR DESCRIPTION


<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--465.org.readthedocs.build/en/465/

<!-- readthedocs-preview cloudstack-documentation end -->