### PR TITLE
cks: update docs for removed createKubernetesCluster API param

### DIFF
--- a/source/plugins/cloudstack-kubernetes-service.rst
+++ b/source/plugins/cloudstack-kubernetes-service.rst
@@ -214,7 +214,6 @@ createKubernetesCluster API can be used to create new Kubernetes cluster. It tak
 - **dockerregistryusername** (username for the docker image private registry; Experimental)
 - **dockerregistrypassword** (password for the docker image private registry; Experimental)
 - **dockerregistryurl** (URL for the docker image private registry; Experimental)
-- **dockerregistryemail** (email of the docker image private registry user; Experimental)
 
 For example:
 
@@ -253,7 +252,7 @@ On successful creation, the new cluster will automatically be started and will s
 
 .. note::
    - A minimum of 2 cores of CPU and 2GB of RAM is needed for deployment. Therefore, the serviceofferingid parameter of createKubernetesCluster API must be provided with the ID of such compute offerings that conform to these requirements.
-   - Private docker registry related parameters of createKubenetesCluster API (dockerregistryusername, dockerregistryusername, dockerregistryurl, dockerregistryemail) provides experimental functionality. To use them during cluster deployment value for global setting, cloud.kubernetes.cluster.experimental.features.enabled, must be set to true by admin beforehand.
+   - Private docker registry related parameters of createKubenetesCluster API (dockerregistryusername, dockerregistryusername, dockerregistryurl) provides experimental functionality. To use them during cluster deployment value for global setting, cloud.kubernetes.cluster.experimental.features.enabled, must be set to true by admin beforehand.
 
 Listing Kubernetes clusters
 ############################

--- a/source/plugins/cloudstack-kubernetes-service.rst
+++ b/source/plugins/cloudstack-kubernetes-service.rst
@@ -252,7 +252,7 @@ On successful creation, the new cluster will automatically be started and will s
 
 .. note::
    - A minimum of 2 cores of CPU and 2GB of RAM is needed for deployment. Therefore, the serviceofferingid parameter of createKubernetesCluster API must be provided with the ID of such compute offerings that conform to these requirements.
-   - Private docker registry related parameters of createKubenetesCluster API (dockerregistryusername, dockerregistryusername, dockerregistryurl) provides experimental functionality. To use them during cluster deployment value for global setting, cloud.kubernetes.cluster.experimental.features.enabled, must be set to true by admin beforehand.
+   - Private docker registry related parameters of createKubenetesCluster API (dockerregistryusername, dockerregistrypassword, dockerregistryurl) provides experimental functionality. To use them during cluster deployment value for global setting, cloud.kubernetes.cluster.experimental.features.enabled, must be set to true by admin beforehand.
 
 Listing Kubernetes clusters
 ############################


### PR DESCRIPTION
dockerregistryemail has been removed in https://github.com/apache/cloudstack/commit/e0a5df50ceb3293c0875b7c2e8961d4e666a0e92

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--477.org.readthedocs.build/en/477/

<!-- readthedocs-preview cloudstack-documentation end -->