### PR TITLE
`id_rsa.pub` location when adding host using SSH Auth

### DIFF
--- a/source/installguide/configuration.rst
+++ b/source/installguide/configuration.rst
@@ -493,7 +493,7 @@ Basic Zone Configuration
 
       Before adding the host in CloudStack do the following,
 
-         - Copy the SSH public key from /var/cloudstack/management/.ssh/id_rsa.pub on the management server
+         - Copy the SSH public key from /var/lib/cloudstack/management/.ssh/id_rsa.pub on the management server
          - Add the copied key to /root/.ssh/authorized_keys file on the host
 
       Select "System SSH Key" and proceed with next steps.


### PR DESCRIPTION
Currently the path of the `id_rsa.pub` file that should be added to the `/root/.ssh/authorized_hosts` isn't correct for `CloudStack 4.20.0`, see: https://docs.cloudstack.apache.org/en/4.20.0.0/installguide/configuration.html

Based on commit: https://github.com/apache/cloudstack/commit/8952cd59559c09e3a1d33842697d508983af33aa

the key is located at: `/var/lib/cloudstack/management/.ssh/id_rsa.pub`

Verified on `CloudStack 4.20.0` during the initial setup for CloudStack.

![Screenshot from 2025-02-08 15-21-31](https://github.com/user-attachments/assets/0becaffd-9fa8-4597-bf6d-c544b9e0d45e)
