### PR TITLE
added steps to install ovftool and virt-win on debian

### DIFF
--- a/source/adminguide/virtual_machines/importing_vmware_vms_into_kvm.rst
+++ b/source/adminguide/virtual_machines/importing_vmware_vms_into_kvm.rst
@@ -104,11 +104,11 @@ Download the ovftool from https://developer.broadcom.com/tools/open-virtualizati
 
     ::
        
-       unzip VMware-ovftool-4.6.3-24031167-lin.x86_64.zip
+       unzip VMware-ovftool-4.6.3-24031167-lin.x86_64.zip -d /usr/local/bin
        
        #create a soft link 
 
-       ln -s /$HOME/ovftool/ovftool /usr/bin/ovftool
+       ln -s /usr/local/bin/ovftool/ovftool /usr/bin/ovftool
 
 If you are hitting the following error when running ovftool, install the dependecy
 

--- a/source/adminguide/virtual_machines/importing_vmware_vms_into_kvm.rst
+++ b/source/adminguide/virtual_machines/importing_vmware_vms_into_kvm.rst
@@ -104,7 +104,7 @@ Download the ovftool from https://developer.broadcom.com/tools/open-virtualizati
 
     ::
        
-       unzip VMware-ovftool-4.6.3-24031167-lin.x86_64.zip -d /usr/local/bin
+       unzip VMware-ovftool-4.6.3-24031167-lin.x86_64.zip -d /usr/local/
        
        #create a soft link 
 

--- a/source/adminguide/virtual_machines/importing_vmware_vms_into_kvm.rst
+++ b/source/adminguide/virtual_machines/importing_vmware_vms_into_kvm.rst
@@ -26,10 +26,8 @@ The virt-v2v output (progress) is logged in the CloudStack agent logs, to help a
 
         dnf install virt-v2v
 
-        cat <<EOF >> /etc/cloudstack/agent/agent.properties
-        virtv2v.verbose.enabled=true
-        EOF
-
+        echo "virtv2v.verbose.enabled=true" >> /etc/cloudstack/agent/agent.properties  
+    
         systemctl restart cloudstack-agent
 
 

--- a/source/adminguide/virtual_machines/importing_vmware_vms_into_kvm.rst
+++ b/source/adminguide/virtual_machines/importing_vmware_vms_into_kvm.rst
@@ -108,7 +108,7 @@ Download the ovftool from https://developer.broadcom.com/tools/open-virtualizati
        
        #create a soft link 
 
-       ln -s /usr/local/bin/ovftool/ovftool /usr/bin/ovftool
+       ln -s /usr/local/ovftool/ovftool /usr/local/bin/ovftool
 
 If you are hitting the following error when running ovftool, install the dependecy
 


### PR DESCRIPTION
added steps to install ovftool and virt-win on debian

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--483.org.readthedocs.build/en/483/

<!-- readthedocs-preview cloudstack-documentation end -->