### PR TITLE
Update KVM incremental snapshot version

### DIFF
--- a/source/adminguide/storage.rst
+++ b/source/adminguide/storage.rst
@@ -1305,7 +1305,7 @@ to a different directory in the same primary storage as the volume; if it is tru
 to the secondary storage. If the snapshot is being taken in a file-based storage (NFS, SharedMountPoint, Local),
 it will be copied directly to its final storage location, according to the configuration.
 
-Since 4.20.0.0, ACS supports incremental snapshots for the KVM hypervisor when using file-based storage (NFS, SharedMountPoint, Local),
+Since 4.21.0.0, ACS supports incremental snapshots for the KVM hypervisor when using file-based storage (NFS, SharedMountPoint, Local),
 to enable incremental snapshots the ``kvm.incremental.snapshot`` configuration must be enabled. Furthermore, in order to take incremental snapshots
 the KVM host must have at least Libvirt version 7.6.0+ and qemu version 6.1+. The size of the snapshot chains
 will be determined by the ``snapshot.delta.max`` configuration, which affects both KVM and XenServer snapshots. 


### PR DESCRIPTION
The feature was supposed to be in 4.20, but ended up being pushed forward. Updates the version to 4.21

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--488.org.readthedocs.build/en/488/

<!-- readthedocs-preview cloudstack-documentation end -->