### PR TITLE
Add sphinx config path

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,8 @@
 version: 2
 
+sphinx:
+  configuration: source/conf.py
+
 build:
   os: "ubuntu-22.04"
   tools:


### PR DESCRIPTION
When trying to download the system VM templates, I noticed that they still point to the old links that were removed. 
This happened because the docs were not built after #484.

However, when trying to build the docs to update them, I was faced with this message:
![image](https://github.com/user-attachments/assets/4fd17a4c-7e45-49ee-ae8d-fb949050738e)

This PR adds the config path to the proper file (see https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/).

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--489.org.readthedocs.build/en/489/

<!-- readthedocs-preview cloudstack-documentation end -->