### PR TITLE
Add/Update UserData /  Update SSH Keys / Add LDAP Note

### DIFF
--- a/source/adminguide/accounts.rst
+++ b/source/adminguide/accounts.rst
@@ -512,6 +512,7 @@ Restricting LDAP Users to a group:
 -  ``ldap.search.group.principle``: this is optional and if set only Users from
    this group are listed.
 
+   .. note:: this is required when using ``linkaccounttoldap``.
 
 LDAP SSL:
 ~~~~~~~~~

--- a/source/adminguide/virtual_machines.rst
+++ b/source/adminguide/virtual_machines.rst
@@ -1264,7 +1264,25 @@ Create an Instance Template that supports SSH Keys.
 Creating the SSH Keypair
 ------------------------
 
-You must make a call to the createSSHKeyPair api method. You can either
+#. Log in to the CloudStack UI.
+
+#. In the left navigation bar, click Compute --> SSH Key Pairs.
+
+#. Click Create a SSH Key Pair.
+
+#. In the dialog, make the following choices:
+
+   -  **Name**: Any desired name for the SSH Key Pair.
+
+   -  **Public key**: (Optional) Public key material of the SSH Key Pair.
+
+      .. note:: If this field is filled in, CloudStack will register the public key.  If this field is left blank, CloudStack will create a new SSH key pair.
+
+   -  **Domain**: (Optional) domain for the SSH Key Pair.
+
+.. note:: If Cloudstack generates a New SSH Key Pair using a public key, it will not save the private key.  When shown, be sure to save a copy of it.
+
+You can also use the ``createSSHKeyPair`` api method to create an SSH Keypair. You can either
 use the CloudStack Python API library or the curl commands to make the
 call to the cloudstack api.
 
@@ -1363,11 +1381,21 @@ The -i parameter tells the ssh client to use a ssh key found at
 Resetting SSH Keys
 ------------------
 
-With the API command resetSSHKeyForVirtualMachine, a user can set or
-reset the SSH keypair assigned to an Instance. A lost or compromised
-SSH keypair can be changed, and the user can access the Instance
-by using the new keypair. Just create or register a new keypair, then
-call resetSSHKeyForVirtualMachine.
+A lost or compromised SSH keypair can be changed, and the user can access the Instance by using the new keypair.
+
+#. Log in to the CloudStack UI.
+
+#. In the left navigation bar, click Compute --> Instances.
+
+#. Choose the Instance.
+
+#. Click on Reset SSH Key Pair button the Instance.
+
+   .. note:: The Instance must be in a Stopped state.
+
+#. Select the SSH Key Pair(s) to add to instance
+
+.. note:: This can also be performed via API: ``resetSSHKeyForVirtualMachine``: Resets the assigned SSH keypair for an Instance.
 
 .. include:: virtual_machines/user-data.rst
 

--- a/source/adminguide/virtual_machines/user-data.rst
+++ b/source/adminguide/virtual_machines/user-data.rst
@@ -12,14 +12,15 @@
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-
-
 User-Data and Meta-Data
------------------------
+=======================
 
 Users can register userdata in CloudStack and refer the registered userdata while
 deploying or editing or reset userdata on an instance. The userdata content can also be
 directly provided while deploying the instance. Userdata content length can be up to 32kb.
+
+Register Userdata
+-----------------
 
 To register a new userdata:
 
@@ -123,7 +124,7 @@ Based on these override policies, "Add Instance" UI form provides relevant optio
 override or append. If it is "Deny Override" then "Add Instance" will not allow adding user specific userdata
 
 Storing and accessing userdata
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 HTTP GET parameters are limited to a length of 2048 bytes, but it is possible
 to store larger user-data blobs by sending them in the body via HTTP POST
@@ -163,6 +164,34 @@ For metadata type, use one of the following:
 
 -  ``instance-id``. The instance name of the instance
 
+Resetting UserData
+------------------
+
+#. Log in to the CloudStack UI.
+
+#. In the left navigation bar, click Compute --> Instances.
+
+#. Choose the Instance to reset userdata.
+
+   .. note:: The Instance must be in a stopped state.
+
+#. Click on Reset Userdata button on the Instance.
+
+   .. note:: If the instance already has userdata applied to it, an extra dialog box will appear.
+
+             - ``Disabled`` (Default) - This will reset the userdata using the already configured values.  Skip the next step.
+
+             - ``Enabled`` - Choose this to override the already configured values.  Continue to next step.
+
+#. In the dialog box, choose one of the following:
+
+   - Stored Userdata: Choose another userdata entry.
+
+      .. note:: Stored Userdata is created under Instances --> User Data
+
+   - Manual Userdata Entry: Manually provide userdata for this Instance
+
+.. note:: This can also be performed via API: ``resetUserDataForVirtualMachine``: Resets the UserData for virtual machine.
 
 Determining the virtual router address without DNS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
adminguide/accounts.rst
-
- **LDAP**: Working with Shapeblue awhile back it was determined that when using `linkaccounttoldap` that `ldap.search.group.principle` is required.  Wanted document this as it may help someone else down the road.

adminguide/virtual_machines.rst
- 
- **Creating SSH Keys**:  Added Documentation on how to do this from UI
- **Resetting SSH Keys**:  Added Documentation on how to do this from UI

adminguide/virtual_machines/user-data.rst
-
- **Fixed Nav**: All of `User-Data and Meta-Data` was nested under the SSH Keys Section.
- **Creating UserData**:  Added Documentation on how to do this from UI
- **Resetting UserData**:  Added to documentation.  Cloudstack has a broken a doc_help mapping for this and no documentation existed. This should address the broken link: https://docs.cloudstack.apache.org/en/latest/adminguide/virtual_machines.html#resetting-userdata


<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--495.org.readthedocs.build/en/495/

<!-- readthedocs-preview cloudstack-documentation end -->