### PR TITLE
Update usage types in the docs

### DIFF
--- a/source/adminguide/usage.rst
+++ b/source/adminguide/usage.rst
@@ -787,7 +787,7 @@ The following table shows all usage types.
 | 4                | NETWORK\_BYTES\_SENT              | Tracks the total            |
 |                  |                                   | number of bytes sent        |
 |                  |                                   | by all the Instances for an |
-|                  |                                   | account. Cloud.com          |
+|                  |                                   | account. CloudStack         |
 |                  |                                   | does not currently          |
 |                  |                                   | track Network traffic       |
 |                  |                                   | per Instance.               |
@@ -796,7 +796,7 @@ The following table shows all usage types.
 |                  |                                   | number of bytes             |
 |                  |                                   | received by all the         |
 |                  |                                   | Instances for an account.   |
-|                  |                                   | Cloud.com does not          |
+|                  |                                   | CloudStack does not         |
 |                  |                                   | currently track             |
 |                  |                                   | Network traffic per         |
 |                  |                                   | Instance.                   |
@@ -837,7 +837,7 @@ The following table shows all usage types.
 |                  |                                   | policy has been             |
 |                  |                                   | created to the time         |
 |                  |                                   | it has been removed.        |
-|                  |                                   | Cloud.com does not          |
+|                  |                                   | CloudStack does not         |
 |                  |                                   | track whether an Instance   |
 |                  |                                   | has been assigned to        |
 |                  |                                   | a policy.                   |

--- a/source/adminguide/usage.rst
+++ b/source/adminguide/usage.rst
@@ -827,7 +827,7 @@ The following table shows all usage types.
 |                  |                                   | also returned.              |
 +------------------+-----------------------------------+-----------------------------+
 | 9                | SNAPSHOT                          | Tracks the total time       |
-|                  |                                   | from when a Template        |
+|                  |                                   | from when a Snapshot        |
 |                  |                                   | has been created to         |
 |                  |                                   | the time it have been       |
 |                  |                                   | destroyed.                  |
@@ -857,7 +857,47 @@ The following table shows all usage types.
 |                  |                                   | VPN User is created         |
 |                  |                                   | until it is removed.        |
 +------------------+-----------------------------------+-----------------------------+
-
+| 21               | VM\_DISK\_IO\_READ                | Tracks the VM Disk usage    |
+|                  |                                   | (I/O Read) for an instance. |
++------------------+-----------------------------------+-----------------------------+
+| 22               | VM\_DISK\_IO\_WRITE               | Tracks the VM Disk usage    |
+|                  |                                   | (I/O Write) for an instance.|
++------------------+-----------------------------------+-----------------------------+
+| 23               | VM\_DISK\_BYTES\_READ             | Tracks the VM Disk usage    |
+|                  |                                   | (Bytes Read) for an         |
+|                  |                                   | instance.                   |
++------------------+-----------------------------------+-----------------------------+
+| 24               | VM\_DISK\_BYTES\_WRITE            | Tracks the VM Disk usage    |
+|                  |                                   | (Bytes Write) for an        |
+|                  |                                   | instance.                   |
++------------------+-----------------------------------+-----------------------------+
+| 25               | VM\_SNAPSHOT                      | Tracks the total time a     |
+|                  |                                   | VM Snapshot has been        |
+|                  |                                   | created to the time when    |
+|                  |                                   | it has been destroyed.      |
++------------------+-----------------------------------+-----------------------------+
+| 26               | VOLUME\_SECONDARY                 | Tracks the Volume           |
+|                  |                                   | usage on secondary storage  |
+|                  |                                   | for an account.             |
++------------------+-----------------------------------+-----------------------------+
+| 27               | VM\_SNAPSHOT\_ON\_PRIMARY         | Tracks the VM Snapshot      |
+|                  |                                   | usage on primary storage    |
+|                  |                                   | for an account.             |
++------------------+-----------------------------------+-----------------------------+
+| 28               | BACKUP                            | Tracks the Backup storage   |
+|                  |                                   | usage for an account.       |
++------------------+-----------------------------------+-----------------------------+
+| 29               | BUCKET                            | Tracks the Bucket storage   |
+|                  |                                   | usage for an account.       |
++------------------+-----------------------------------+-----------------------------+
+| 30               | NETWORK                           | Tracks the Network usage    |
+|                  |                                   | from the time it is         |
+|                  |                                   | created until it is removed.|
++------------------+-----------------------------------+-----------------------------+
+| 31               | VPC                               | Tracks the VPC usage        |
+|                  |                                   | from the time it is         |
+|                  |                                   | created until it is removed.|
++------------------+-----------------------------------+-----------------------------+
 
 Example response from listUsageRecords
 --------------------------------------


### PR DESCRIPTION
This PR updates/sync the usage types in docs with the API response and code.

Fixes https://github.com/apache/cloudstack/issues/10813 

Current doc: https://docs.cloudstack.apache.org/en/latest/adminguide/usage.html#usage-types.

list usagetypes API response =>
```
(usageenv) 🐱 > list usagetypes 
{
  "count": 25,
  "usagetype": [
    {
      "description": "Running Vm Usage",
      "usagetypeid": 1
    },
    {
      "description": "Allocated Vm Usage",
      "usagetypeid": 2
    },
    {
      "description": "IP Address Usage",
      "usagetypeid": 3
    },
    {
      "description": "Network Usage (Bytes Sent)",
      "usagetypeid": 4
    },
    {
      "description": "Network Usage (Bytes Received)",
      "usagetypeid": 5
    },
    {
      "description": "Volume Usage",
      "usagetypeid": 6
    },
    {
      "description": "Template Usage",
      "usagetypeid": 7
    },
    {
      "description": "ISO Usage",
      "usagetypeid": 8
    },
    {
      "description": "Snapshot Usage",
      "usagetypeid": 9
    },
    {
      "description": "Security Group Usage",
      "usagetypeid": 10
    },
    {
      "description": "Load Balancer Usage",
      "usagetypeid": 11
    },
    {
      "description": "Port Forwarding Usage",
      "usagetypeid": 12
    },
    {
      "description": "Network Offering Usage",
      "usagetypeid": 13
    },
    {
      "description": "VPN users usage",
      "usagetypeid": 14
    },
    {
      "description": "VM Disk usage(I/O Read)",
      "usagetypeid": 21
    },
    {
      "description": "VM Disk usage(I/O Write)",
      "usagetypeid": 22
    },
    {
      "description": "VM Disk usage(Bytes Read)",
      "usagetypeid": 23
    },
    {
      "description": "VM Disk usage(Bytes Write)",
      "usagetypeid": 24
    },
    {
      "description": "VM Snapshot storage usage",
      "usagetypeid": 25
    },
    {
      "description": "Volume on secondary storage usage",
      "usagetypeid": 26
    },
    {
      "description": "VM Snapshot on primary storage usage",
      "usagetypeid": 27
    },
    {
      "description": "Backup storage usage",
      "usagetypeid": 28
    },
    {
      "description": "Bucket storage usage",
      "usagetypeid": 29
    },
    {
      "description": "Network usage",
      "usagetypeid": 30
    },
    {
      "description": "VPC usage",
      "usagetypeid": 31
    }
  ]
}
(usageenv) 🐱 > 
```

code =>

https://github.com/apache/cloudstack/blob/39c5641cbe674b19bc77082b850565f634a7cb84/api/src/main/java/org/apache/cloudstack/usage/UsageTypes.java#L24-L50

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--504.org.readthedocs.build/en/504/

<!-- readthedocs-preview cloudstack-documentation end -->