### PR TITLE
Update network offering usage record (inline with the response)

### DIFF
--- a/source/adminguide/usage.rst
+++ b/source/adminguide/usage.rst
@@ -680,8 +680,6 @@ Load Balancer Policy or Port Forwarding Rule Usage Record Format
 
 -  usageid - ID of the load balancer policy or port forwarding rule
 
--  usagetype - A number representing the usage type (see Usage Types)
-
 -  startdate, enddate - The range of time for which the usage is
    aggregated; see Dates in the Usage Record
 
@@ -706,15 +704,11 @@ Network Offering Usage Record Format
 
 -  rawusage – A number representing the actual usage in hours
 
--  usageid – ID of the Network offering
+-  offeringid – ID of the Network offering
 
--  usagetype – A number representing the usage type (see Usage Types)
+-  virtualmachineid – The ID of the Instance
 
--  offeringid – Network offering ID
-
--  virtualMachineId – The ID of the Instance
-
--  virtualMachineId – The ID of the Instance
+-  isdefault – The default nic of the Instance
 
 -  startdate, enddate – The range of time for which the usage is
    aggregated; see Dates in the Usage Record
@@ -741,8 +735,6 @@ VPN User Usage Record Format
 -  rawusage – A number representing the actual usage in hours
 
 -  usageid – VPN User ID
-
--  usagetype – A number representing the usage type (see Usage Types)
 
 -  startdate, enddate – The range of time for which the usage is
    aggregated; see Dates in the Usage Record


### PR DESCRIPTION
Update network offering usage record (inline with the response).

```
(usageenv) 🐱 > list usagerecords startdate=2025-05-11 enddate=2025-05-13 type=13 usageid=bfcb52bf-cb33-4c7d-bd9d-9b4b57d65a77
{
  "count": 110,
  "usagerecord": [
    {
      "account": "admin",
      "accountid": "a5f9d055-1ea1-11f0-8a38-1e00b50002f5",
      "description": "Network offering DefaultIsolatedNetworkOfferingWithSourceNatService (bfcb52bf-cb33-4c7d-bd9d-9b4b57d65a77) usage for VM testvm01 (0c74f18a-2f1b-4bbe-b17e-bd16f4e55d86) ",
      "domain": "ROOT",
      "domainid": "676c3952-1ea1-11f0-8a38-1e00b50002f5",
      "domainpath": "/",
      "enddate": "2025-05-11'T'00:59:59+00:00",
      "isdefault": true,
      "offeringid": "bfcb52bf-cb33-4c7d-bd9d-9b4b57d65a77",
      "rawusage": "1",
      "startdate": "2025-05-11'T'00:00:00+00:00",
      "tags": [],
      "usage": "1 Hrs",
      "usagetype": 13,
      "virtualmachineid": "0c74f18a-2f1b-4bbe-b17e-bd16f4e55d86",
      "zoneid": "cd989e1a-0024-439d-8164-7db39e046c6f"
    },
    {
      "account": "admin",
      "accountid": "a5f9d055-1ea1-11f0-8a38-1e00b50002f5",
      "description": "Network offering DefaultIsolatedNetworkOfferingWithSourceNatService (bfcb52bf-cb33-4c7d-bd9d-9b4b57d65a77) usage for VM testvm02 (617f7798-7a5f-4eb7-9d13-40a3eab641df) ",
      "domain": "ROOT",
      "domainid": "676c3952-1ea1-11f0-8a38-1e00b50002f5",
      "domainpath": "/",
      "enddate": "2025-05-11'T'00:59:59+00:00",
      "isdefault": true,
      "offeringid": "bfcb52bf-cb33-4c7d-bd9d-9b4b57d65a77",
      "rawusage": "1",
      "startdate": "2025-05-11'T'00:00:00+00:00",
      "tags": [],
      "usage": "1 Hrs",
      "usagetype": 13,
      "virtualmachineid": "617f7798-7a5f-4eb7-9d13-40a3eab641df",
      "zoneid": "cd989e1a-0024-439d-8164-7db39e046c6f"
    },
    {
      "account": "admin",
      "accountid": "a5f9d055-1ea1-11f0-8a38-1e00b50002f5",
      "description": "Network offering DefaultIsolatedNetworkOfferingWithSourceNatService (bfcb52bf-cb33-4c7d-bd9d-9b4b57d65a77) usage for VM testvm01 (0c74f18a-2f1b-4bbe-b17e-bd16f4e55d86) ",
      "domain": "ROOT",
      "domainid": "676c3952-1ea1-11f0-8a38-1e00b50002f5",
      "domainpath": "/",
      "enddate": "2025-05-11'T'01:59:59+00:00",
      "isdefault": true,
      "offeringid": "bfcb52bf-cb33-4c7d-bd9d-9b4b57d65a77",
      "rawusage": "1",
      "startdate": "2025-05-11'T'01:00:00+00:00",
      "tags": [],
      "usage": "1 Hrs",
      "usagetype": 13,
      "virtualmachineid": "0c74f18a-2f1b-4bbe-b17e-bd16f4e55d86",
      "zoneid": "cd989e1a-0024-439d-8164-7db39e046c6f"
    },
    ...
```


<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--505.org.readthedocs.build/en/505/

<!-- readthedocs-preview cloudstack-documentation end -->