### PR TITLE
polish: Fix some inconsistencies in object names and messages

### DIFF
--- a/source/adminguide/api.rst
+++ b/source/adminguide/api.rst
@@ -94,15 +94,15 @@ User Data and Meta Data via Config Drive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Config drive is an ISO file that is mounted as a cd-rom on a user Instance and
-contains related userdata, metadata (incl. ssh-keys) and
+contains related user data, metadata (incl. ssh-keys) and
 password files.
 
 Enable config drive
 ~~~~~~~~~~~~~~~~~~~
 To use the config drive the Network offering must have the “ConfigDrive”
-provider selected for the userdata service.
+provider selected for the user data service.
 
-If the networkoffering uses ConfigDrive for userdata and the Template is
+If the networkoffering uses ConfigDrive for user data and the Template is
 password enabled, the password string for the Instance is placed in the
 vm_password.txt file and it is included in the ISO.
 
@@ -115,11 +115,11 @@ supporting 1 cd rom drive is still available.
 
 At password reset or update of user data, the Config Drive ISO
 will be rebuilt. The existing ISO is mounted on a temporary directory,
-password, userdata or ssh-keys are updated and a new ISO is built from the
+password, user data or ssh-keys are updated and a new ISO is built from the
 updated directory structure.
 
 In case of a password reset, the new password will be picked-up at Instance start.
-To access the updated userdata, the user needs to remount the config drive ISO.
+To access the updated user data, the user needs to remount the config drive ISO.
 
 When an Instance is stopped, the ConfigDrive network element will trigger the
 Secondary Storage VM to remove the ISO from the secondary storage.

--- a/source/adminguide/autoscale_with_virtual_router.rst
+++ b/source/adminguide/autoscale_with_virtual_router.rst
@@ -170,7 +170,7 @@ Specify the following:
    For more information, see `“Affinity Groups”
    <virtual_machines.html#affinity-groups>`_.
 
--  Userdata: The userdata of the Instances.
+-  User data: The user data of the Instances.
 
    For more information, see `“User-Data and Meta-Data”
    <virtual_machines.html#user-data-and-meta-data>`_.
@@ -287,7 +287,7 @@ then click Edit AutoScale Instance Profile button.
 
 |autoscale-vmgroup-profile-update.png|
 
-You are able to reset userdata of the Instance, by clicking Reset Userdata on AutoScale Instance Group button.
+You are able to reset user data of the Instance, by clicking Reset User data on AutoScale Instance Group button.
 
 |autoscale-vmgroup-profile-reset-userdata.png|
 
@@ -399,5 +399,5 @@ a service assigned to a rule inside the context of AutoScale.
 .. |autoscale-vmgroup-profile-update.png| image:: /_static/images/autoscale-vmgroup-profile-update.png
    :alt: Update AutoScale Instance Profile.
 .. |autoscale-vmgroup-profile-reset-userdata.png| image:: /_static/images/autoscale-vmgroup-profile-reset-userdata.png
-   :alt: Reset Userdata in AutoScale Instance Profile.
+   :alt: Reset User data in AutoScale Instance Profile.
 

--- a/source/adminguide/networking.rst
+++ b/source/adminguide/networking.rst
@@ -106,7 +106,7 @@ IP addresses.
 
 -  CloudStack does not assign IP addresses to instances.
 
--  Userdata and metadata can be passed to the instance using a config drive
+-  User data and metadata can be passed to the instance using a config drive
    (which must be enabled in the network service offering)
 
 Example GUI dialog box (for a regular user account) is shown below:

--- a/source/adminguide/networking/dynamic_static_routing.rst
+++ b/source/adminguide/networking/dynamic_static_routing.rst
@@ -41,7 +41,7 @@ Network mode indicates the mode with which the isolated network or VPC will oper
 There are two valid options
 
 - NATTED. This is the default network mode of isolated networks. The VR of isolated networks and VPCs provides Source NAT services, as well as Static NAT, Load Balancer, Port Forwarding, Vpn if the network offering supports.
-- ROUTED. For isolated networks in ROUTED mode, the VR no longer supports Source NAT, Static NAT, Load Balancer, Port Forwarding and Vpn. The supported services are Dns, Dhcp, Userdata, Firewall (for isolated networks) and Network ACL (for vpc and vpc networks).
+- ROUTED. For isolated networks in ROUTED mode, the VR no longer supports Source NAT, Static NAT, Load Balancer, Port Forwarding and Vpn. The supported services are Dns, Dhcp, User data, Firewall (for isolated networks) and Network ACL (for vpc and vpc networks).
 
 
 About Routing mode

--- a/source/adminguide/networking/remote_access_vpn.rst
+++ b/source/adminguide/networking/remote_access_vpn.rst
@@ -133,7 +133,7 @@ To enable VPN for a VPC:
 
    -  Site-to-Site VPNs
 
-   -  Network ACL Lists
+   -  Network ACLs
 
 #. In the Router node, select Public IP Addresses.
 

--- a/source/adminguide/networking/site_to_site_vpn.rst
+++ b/source/adminguide/networking/site_to_site_vpn.rst
@@ -236,7 +236,7 @@ Creating a VPN gateway for the VPC
 
    -  Site-to-Site VPNs
 
-   -  Network ACL Lists
+   -  Network ACLs
 
 #. Select Site-to-Site VPN.
 
@@ -299,7 +299,7 @@ Creating a VPN Connection
 
    -  Site-to-Site VPNs
 
-   -  Network ACL Lists
+   -  Network ACLs
 
 #. Select Site-to-Site VPN.
 
@@ -431,7 +431,7 @@ Restarting and Removing a VPN Connection
 
    -  Site-to-Site VPNs
 
-   -  Network ACL Lists
+   -  Network ACLs
 
 #. Select Site-to-Site VPN.
 

--- a/source/adminguide/networking/virtual_private_cloud_config.rst
+++ b/source/adminguide/networking/virtual_private_cloud_config.rst
@@ -315,7 +315,7 @@ Define a Network Access Control List (ACL) to control incoming
 (ingress) and outgoing (egress) traffic between the associated Network Tier
 and external Networks (other Network Tiers of the VPC as well as public Networks).
 
-About Network ACL Lists
+About Network ACLs
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 In CloudStack terminology, a Network ACL is a group of Network ACL rules.
@@ -357,7 +357,7 @@ Afterwards traffic can be white- or blacklisted.
   connection
   
 
-Creating ACL Lists
+Creating ACLs
 ^^^^^^^^^^^^^^^^^^
 
 #. Log in to the CloudStack UI as an administrator or end User.
@@ -391,18 +391,18 @@ Creating ACL Lists
 
    -  Site-to-Site VPNs
 
-   -  Network ACL Lists
+   -  Network ACLs
 
-#. Select Network ACL Lists.
+#. Select Network ACLs.
 
    The following default rules are displayed in the Network ACLs page:
    default\_allow, default\_deny.
 
-#. Click Add ACL Lists, and specify the following:
+#. Click Add Network ACL, and specify the following:
 
-   -  **ACL List Name**: A name for the ACL list.
+   -  **ACL Name**: A name for the ACL.
 
-   -  **Description**: A short description of the ACL list that can be
+   -  **Description**: A short description of the ACL that can be
       displayed to users.
 
 
@@ -420,15 +420,15 @@ Creating an ACL Rule
 
 #. Click the Configure button of the VPC.
 
-#. Select Network ACL Lists.
+#. Select Network ACLs.
 
-   In addition to the custom ACL lists you have created, the following
+   In addition to the custom ACLs you have created, the following
    default rules are displayed in the Network ACLs page: default\_allow,
    default\_deny.
 
-#. Select the desired ACL list.
+#. Select the desired ACL.
 
-#. Select the ACL List Rules tab.
+#. Select the ACL Rules tab.
 
    To add an ACL rule, fill in the following fields to specify what kind
    of network traffic is allowed in the VPC.
@@ -471,23 +471,23 @@ Creating an ACL Rule
    tab.
 
 
-Creating a Tier with Custom ACL List
+Creating a Tier with Custom ACL
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #. Create a VPC.
 
-#. Create a custom ACL list.
+#. Create a custom ACL.
 
-#. Add ACL rules to the ACL list.
+#. Add ACL rules to the ACL.
 
 #. Create a tier in the VPC.
 
-   Select the desired ACL list while creating a tier.
+   Select the desired ACL while creating a tier.
 
 #. Click OK.
 
 
-Assigning a Custom ACL List to a Tier
+Assigning a Custom ACL to a Tier
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #. Create a VPC.
@@ -496,17 +496,17 @@ Assigning a Custom ACL List to a Tier
 
 #. Associate the tier with the default ACL rule.
 
-#. Create a custom ACL list.
+#. Create a custom ACL.
 
-#. Add ACL rules to the ACL list.
+#. Add ACL rules to the ACL.
 
 #. Select the tier for which you want to assign the custom ACL.
 
-#. Click the Replace ACL List icon. |replace-acl-icon.png|
+#. Click the Replace ACL icon. |replace-acl-icon.png|
 
-   The Replace ACL List dialog is displayed.
+   The Replace ACL dialog is displayed.
 
-#. Select the desired ACL list.
+#. Select the desired ACL.
 
 #. Click OK.
 
@@ -558,7 +558,7 @@ with duplicated VLAN and IP are allowed in the same data center.
 
    -  Site-to-Site VPNs
 
-   -  Network ACL Lists
+   -  Network ACLs
 
 #. Select Private Gateways.
 
@@ -801,7 +801,7 @@ associated to more than one network at a time.
 
    -  Site-to-Site VPNs
 
-   -  Network ACL Lists
+   -  Network ACLs
 
 #. Select IP Addresses.
 
@@ -859,7 +859,7 @@ still belongs to the same VPC.
 
    -  Site-to-Site VPNs
 
-   -  Network ACL Lists
+   -  Network ACLs
 
 #. Select Public IP Addresses.
 
@@ -920,7 +920,7 @@ function only if they are defined on the default network.
 
    -  Site-to-Site VPNs
 
-   -  Network ACL Lists
+   -  Network ACLs
 
 #. In the Router node, select Public IP Addresses.
 
@@ -1086,7 +1086,7 @@ Creating an External LB Rule
 
    -  Site-to-Site VPNs
 
-   -  Network ACL Lists
+   -  Network ACLs
 
 #. In the Router node, select Public IP Addresses.
 
@@ -1354,7 +1354,7 @@ Adding a Port Forwarding Rule on a VPC
 
    -  Site-to-Site VPNs
 
-   -  Network ACL Lists
+   -  Network ACLs
 
 #. In the Router node, select Public IP Addresses.
 
@@ -1473,7 +1473,7 @@ is not required.
 .. |add-tier.png| image:: /_static/images/add-tier.png
    :alt: adding a tier to a vpc.
 .. |replace-acl-icon.png| image:: /_static/images/replace-acl-icon.png
-   :alt: button to replace an ACL list
+   :alt: button to replace an ACL
 .. |add-new-gateway-vpc2.png| image:: /_static/images/add-new-gateway-vpc2.png
    :alt: adding a private gateway for the VPC.
 .. |add-vm-vpc.png| image:: /_static/images/add-vm-vpc.png

--- a/source/adminguide/systemvm.rst
+++ b/source/adminguide/systemvm.rst
@@ -829,7 +829,7 @@ it is upgraded:
 
 -  SecurityGroup
 
--  UserData
+-  User Data
 
 -  DHCP
 

--- a/source/adminguide/templates.rst
+++ b/source/adminguide/templates.rst
@@ -271,11 +271,11 @@ To upload a Template:
    -  **Tag**: The tag for the template. This tag can be used with host tags to
       allow deployment of Instances on specific hosts.
 
-   -  **Userdata**: The registered Userdata are listed. Select the
+   -  **User data**: The registered User data are listed. Select the
       desired one.
 
-   -  **Userdata link policy**: Select the userdata override policy as required. 
-      For more information on userdata and override link policy, please check `Userdata section <virtual_machines.html#user-data-and-meta-data>`_.
+   -  **User data link policy**: Select the user data override policy as required.
+      For more information on user data and override link policy, please check `User data section <virtual_machines.html#user-data-and-meta-data>`_.
 
 
    -  **Hypervisor**: The supported hypervisors are listed. Select the

--- a/source/adminguide/virtual_machines/user-data.rst
+++ b/source/adminguide/virtual_machines/user-data.rst
@@ -17,40 +17,40 @@
 User-Data and Meta-Data
 -----------------------
 
-Users can register userdata in CloudStack and refer the registered userdata while
-deploying or editing or reset userdata on an instance. The userdata content can also be
-directly provided while deploying the instance. Userdata content length can be up to 32kb.
+Users can register user data in CloudStack and refer the registered user data while
+deploying or editing or reset user data on an instance. The user data content can also be
+directly provided while deploying the instance. User data content length can be up to 32kb.
 
-To register a new userdata:
+To register a new user data:
 
 #. Log in to the CloudStack UI.
 
-#. In the left navigation bar, click Compute and then User Data.
+#. In the left navigation bar, click Compute and then User Data Library.
 
-#. Click Register a userdata.
+#. Click Register user data.
 
 #. In the dialog, make the following choices:
 
-   -  **Name**: Any desired name for the userdata.
+   -  **Name**: Any desired name for the user data.
 
-   -  **Userdata**: Plain userdata content. CloudStack UI does base64 encoding.
+   -  **User data**: Plain user data content. CloudStack UI does base64 encoding.
 
-   -  **Userdata parameters**: Comma separated list of variables which (if any) declared
-      in userdata content.
+   -  **User data parameters**: Comma separated list of variables which (if any) declared
+      in user data content.
 
-   -  **Domain**: An optional domain for the userdata.
+   -  **Domain**: An optional domain for the user data.
 
-   -  **Account**: An optional account for the userdata.
+   -  **Account**: An optional account for the user data.
 
 .. image:: /_static/images/register_userdata.png
    :width: 400px
    :align: center
-   :alt: Regiser userdata dialog box
+   :alt: Regiser user data dialog box
 
-If userdata content has variables declared in it, user can register the Userdata
-with userdata parameters.
+If user data content has variables declared in it, user can register the User data
+with user data parameters.
 
-For example, if userdata content is like below having a custom variable "variable1"
+For example, if user data content is like below having a custom variable "variable1"
 
    .. code:: bash
 
@@ -60,69 +60,69 @@ For example, if userdata content is like below having a custom variable "variabl
          - echo 'TestVariable {{ ds.meta_data.variable1 }}' >> /tmp/variable
          - echo 'Hostname {{ ds.meta_data.public_hostname }}' > /tmp/hostname
 
-Userdata has to be registered with userdata parameter "variable1" like below
+User data has to be registered with user data parameter "variable1" like below
 
 .. image:: /_static/images/register_userdata_with_variables.png
    :width: 400px
    :align: center
-   :alt: Regiser userdata with variables dialog box
+   :alt: Regiser user data with variables dialog box
 
-If the variables in userdata content are of a predefined metadata like "public_hostname"
-or "instance_id", then userdata parameters should not declare these variables. That is
+If the variables in user data content are of a predefined metadata like "public_hostname"
+or "instance_id", then user data parameters should not declare these variables. That is
 the reason in the above example "public_hostname" is not declared.
 
 There are three CloudStack APIs that can be used to provide user-data to instance:
 deployVirtualMachine, updateVirtualMachine and resetUserDataForVirtualMachine.
 These APIs accepts parameters ``userdataid`` and ``userdatadetails``.
 userdatadetails is to specify the custom values for the variables which are declared
-in userdata in a key value parameter map details.
+in user data in a key value parameter map details.
 
 .. image:: /_static/images/deployvm_userdata.png
    :width: 400px
    :align: center
-   :alt: Provide userdata id or userdata text dialog box
+   :alt: Provide user data id or user data text dialog box
 
-If the userdata contains variables that are declared during registration then those values
+If the user data contains variables that are declared during registration then those values
 has to be specified like below,
 
 .. image:: /_static/images/deployvm_userdata_with_variables.png
    :width: 400px
    :align: center
-   :alt: Provide userdata id or userdata with variables text dialog box
+   :alt: Provide userdata id or user data with variables text dialog box
 
 These details will be saved as meta-data file(s) in both config drive and virtual router,
 which in turn support jinja based instance meta-data feature of cloud-init,
 refer to https://cloudinit.readthedocs.io/en/latest/topics/instancedata.html.
 
-These APIs also support the parameter ``userdata=`` to provide the userdata content
+These APIs also support the parameter ``userdata=`` to provide the user data content
 directly. The value for this parameter must be a `base64 <https://www.base64encode.org/>`_-encoded
 multi-part MIME message. See further below for an example of what this should look like.
 
-The registered UserData can be linked to a Template or ISO on registration/upload/editing
-using linkUserDataToTemplate API. The same API can be used to unlink the mapping of userdata and Template.
+The registered User Data can be linked to a Template or ISO on registration/upload/editing
+using linkUserDataToTemplate API. The same API can be used to unlink the mapping of user data and Template.
 
-While linking userData to a Template/ISO userdata override policy has to be specified.
+While linking user Data to a Template/ISO user data override policy has to be specified.
 Following are the override policies available: 
 
-Allow Override: Allow users to override UserData for the Template during instance deployment or on reset.
+Allow Override: Allow users to override User Data for the Template during instance deployment or on reset.
                 This is the default override policy if not specified 
 
-Deny Override: Override of UserData isn’t allowed during instance deployment or on reset.
+Deny Override: Override of User Data isn’t allowed during instance deployment or on reset.
 
-Append Only: Don’t allow users to override linked UserData but allow users to pass userdata content 
-             or ID that should be appended to the linked UserData of the Template. When the users pass userdata it is appended to the Template userdata in the form of a multipart MIME message
+Append Only: Don’t allow users to override linked User Data but allow users to pass user data content
+             or ID that should be appended to the linked User Data of the Template. When the users pass user data it is appended to the Template user data in the form of a multipart MIME message
 
 This is how it looks like in Template/ISO register/upload/edit forms.
 
 .. image:: /_static/images/userdata_template_link.png
    :width: 400px
    :align: center
-   :alt: Linking userdata to template/ISO
+   :alt: Linking user data to template/ISO
 
 Based on these override policies, "Add Instance" UI form provides relevant options to either
-override or append. If it is "Deny Override" then "Add Instance" will not allow adding user specific userdata
+override or append. If it is "Deny Override" then "Add Instance" will not allow adding user specific user data
 
-Storing and accessing userdata
+Storing and accessing user data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 HTTP GET parameters are limited to a length of 2048 bytes, but it is possible
@@ -130,14 +130,14 @@ to store larger user-data blobs by sending them in the body via HTTP POST
 instead of GET.
 
 From inside the instance, the user-data is accessible via the virtual router,
-if the UserData service is enabled on the network offering.
+if the User Data service is enabled on the network offering.
 
 If you are using the DNS service of the virtual router, a special hostname
 called `data-server.` is provided, that will point to a valid user-data server.
 
 Otherwise you have to determine the virtual router address via other means,
 such as DHCP leases. Be careful to scan all routers if you have multiple
-networks attached to an instance, in case not all of them have the UserData service
+networks attached to an instance, in case not all of them have the User Data service
 enabled.
 
 User-data is available from the URL ``http://data-server./latest/user-data``
@@ -224,8 +224,8 @@ Custom user-data example
 
 This example uses cloud-init to automatically update all OS packages on the first launch.
 
-#. Register the following user-data in CloudStack. If APIs are used to register userdata or to
-   provide direct userdata text then userdata needs to be wrapped into a multi-part MIME message
+#. Register the following user-data in CloudStack. If APIs are used to register user data or to
+   provide direct user data text then user data needs to be wrapped into a multi-part MIME message
    and encoded in base64:
 
    .. code:: bash
@@ -250,8 +250,8 @@ This example uses cloud-init to automatically update all OS packages on the firs
       package_upgrade: true
       EOF
    
-#. Deploy an instance with this user-data either by providing the UUID of the registerd userdata
-   or by providing base64 encoded userdata:
+#. Deploy an instance with this user-data either by providing the UUID of the registerd user data
+   or by providing base64 encoded user data:
 
    .. code:: bash
 
@@ -259,9 +259,9 @@ This example uses cloud-init to automatically update all OS packages on the firs
 
    .. code:: bash
 
-      cmk deploy virtualmachine name=..... userdataid=<Userdata UUID>
+      cmk deploy virtualmachine name=..... userdataid=<User data UUID>
 
-.. note:: When using multipart userdata, cloud-init expects userdata format of one particular type only in one multipart section.
+.. note:: When using multipart user data, cloud-init expects user data format of one particular type only in one multipart section.
 
 Disclaimer
 ~~~~~~~~~~

--- a/source/conceptsandterminology/network_setup.rst
+++ b/source/conceptsandterminology/network_setup.rst
@@ -55,7 +55,7 @@ VPN support                No                                   Yes
 Port forwarding            Physical                             Physical and Virtual
 1:1 NAT                    Physical                             Physical and Virtual
 Source NAT                 No                                   Physical and Virtual
-Userdata                   Yes                                  Yes
+User data                  Yes                                 Yes
 Network usage monitoring   sFlow / netFlow at physical router   Hypervisor and Virtual Router
 DNS and DHCP               Yes                                  Yes
 =========================  ===================================  ===============================

--- a/source/plugins/ipv6.rst
+++ b/source/plugins/ipv6.rst
@@ -101,7 +101,7 @@ The following are not yet supported:
 
 #. Security groups
 
-#. Userdata and metadata
+#. User data and metadata
 
 #. Passwords
 

--- a/source/plugins/ipv6.rst
+++ b/source/plugins/ipv6.rst
@@ -322,7 +322,7 @@ These operations are also available using UI in the network details view of an I
 IPv6 ACL
 ########
 
-IPv6 ACL rules for an IPv6 supported VPC Network Tier can be managed using Network ACL lists for the VPC. IPv6 CIDRs can be specified while adding or updating an ACL rule.
+IPv6 ACL rules for an IPv6 supported VPC Network Tier can be managed using Network ACLs for the VPC. IPv6 CIDRs can be specified while adding or updating an ACL rule.
 
 |add-ipv6-acl-rule-form.png|
 |ipv6-acl-list.png|
@@ -343,4 +343,4 @@ IPv6 ACL rules for an IPv6 supported VPC Network Tier can be managed using Netwo
 .. |add-ipv6-acl-rule-form.png| image:: /_static/images/add-ipv6-acl-rule-form.png
    :alt: Add IPv6 ACL rule.
 .. |ipv6-acl-list.png| image:: /_static/images/ipv6-acl-list.png
-   :alt: IPv6 ACL rule in Network ACL list.
+   :alt: IPv6 ACL rule in Network ACL.

--- a/source/plugins/nsx-plugin.rst
+++ b/source/plugins/nsx-plugin.rst
@@ -28,7 +28,7 @@ The VMware NSX Plugin introduces VMware NSX 4 as a network service provider in C
 - Port Forwarding between “public” networks and VPC network tier
 - External load balancing – between VPCs network tiers and “public” networks (runs on Edge Cluster)
 - Internal load balancing – between VPC network tiers
-- Password injection, UserData and SSH Keys
+- Password injection, User Data and SSH Keys
 - External, Internal DNS
 - DHCP
 - Kubernetes host orchestration, supporting CKS on VPCs


### PR DESCRIPTION
Documentation PR for https://github.com/apache/cloudstack/pull/10856

#### ACL Lists

1. Replace ACL Lists with ACLs as Access Control List Lists doesn't make sense
2. Replace Add ACL with Add ACL rule wherever a rule is being added


#### User data

1. Following industry conventions, User data should be written as two words
3. The term "User Data" used in the main menu creates some confusion, whether it is singular or plural. So renamed it to "User Data Library" where users can register new User Data.
4. User data should not be followed by "a"