### PR TITLE
removed duplicate CloudStack DRS feature from the list

### DIFF
--- a/source/releasenotes/about.rst
+++ b/source/releasenotes/about.rst
@@ -62,7 +62,6 @@ new features. Some of the highlights include:
 • CloudStack DRS
 • OAuth2 Authentication
 • VNF Appliances Support
-• CloudStack DRS
 • CloudStack Snapshot Copy
 • Scheduled Instance Lifecycle Operations
 • Guest OS Management


### PR DESCRIPTION
The feature CloudStack DRS was listed twice in the new features list. One got removed now.

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--532.org.readthedocs.build/en/532/

<!-- readthedocs-preview cloudstack-documentation end -->