### PR TITLE
extensions: update note on inbuilt orcehstrator

### DIFF
--- a/source/adminguide/extensions.rst
+++ b/source/adminguide/extensions.rst
@@ -79,7 +79,7 @@ An Orchestrator extension enables CloudStack to delegate VM orchestration to an 
    |extension.png|
 
 
-CloudStack provides sample in-built orchestrator extensions for demonstration and testing purposes.
+CloudStack provides in-built Orchestrator Extensions for Proxmox and Hyper-V which work with Proxmox and Hyper-V environments out of the box.
 
 .. note::
    - When a CloudStack host linked to an orchestrator extension is placed into Maintenance mode, all running instances on the host will be stopped.

--- a/source/adminguide/extensions/inbuilt_extensions.rst
+++ b/source/adminguide/extensions/inbuilt_extensions.rst
@@ -16,7 +16,7 @@
 In-built Orchestrator Extensions
 ================================
 
-CloudStack provides sample in-built Orchestrator Extensions for Proxmox and Hyper-V. These Extensions are intended for demonstration and testing purposes.
+CloudStack provides in-built Orchestrator Extensions for Proxmox and Hyper-V. These extensions work with Proxmox and Hyper-V environments out of the box, and can also serve as reference implementations for anyone looking to develop new custom extensions.
 The Extension files are located at `/usr/share/cloudstack-management/extensions/Proxmox` and `/usr/share/cloudstack-management/extensions/HyperV` respectively.
 The Proxmox Extension is written in shell script, while the Hyper-V Extension is written in python.
 Both of these Extensions support some custom actions in addition to the standard VM actions like deploy, start, stop, reboot, status and delete.


### PR DESCRIPTION
Now that we have a section on limitations, operator may refer that to see things which are not supported at the moment.

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--554.org.readthedocs.build/en/554/

<!-- readthedocs-preview cloudstack-documentation end -->