### PR TITLE
Documentation related to Persistent domainXML

### DIFF
--- a/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
+++ b/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
@@ -351,6 +351,9 @@ The API supports the `hostid` parameter for stopped instances on the KVM hypervi
 
    cmk unmanage virtualmachine id=<instance-id> hostid=<host-id>
 
+.. note::
+   Instances with Config Drive cannot be unmanaged by default, as the Config Drive ISO will be removed during the unmanage operation. To unmanage such instances via the API, use the forced=true parameter.
+
 The API has the following preconditions:
 
 - The Instance must not be destroyed
@@ -455,7 +458,9 @@ Prerequisites
 - Currently, it's supported to only use NFS and Local storage as the destination Primary Storage pools in CloudStack
 - Currently, only libvirt-based instances can be migrated
 
-.. note:: Allocate a NIC to any instance without one immediately after importing it into CloudStack.
+.. note:: 
+   - Allocate a NIC to any instance without one immediately after importing it into CloudStack.
+   - Instances imported on a Config Drive network must be stopped and started after import to properly attach the Config Drive ISO.
 
 listVmsForImport API
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
+++ b/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
@@ -362,6 +362,22 @@ Preserving unmanaged Instance NICs
 The zone setting: unmanage.vm.preserve.nics can be used to preserve Instance NICs and its MAC addresses after unmanaging them. If set to true, the Instance NICs (and their MAC addresses) are preserved when unmanaging it. Otherwise, NICs are removed and MAC addresses can be reassigned.
 
 
+KVM Specific: Persistent Domain XML when unmanaging Instances
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since 4.22, domain XML will be made persistent when Instance is unmanaged from CloudStack. This will allow to manage the Instance outside of CloudStack using virsh or other libvirt tools. The domain XML will be stored in directory /etc/libvirt/qemu.
+
+Domain XML is taken from Instance but varies based on their state:
+
+- Running Instance
+   - Domain XML is contructed from the Instance and persisted on the Host where the Instance is running
+- Stopped Instance
+   - Domain XML is constructed from the Instance details available in CloudStack database
+   - Domain XML will pe persisted on the last host where the Instance was running before stopping it
+
+.. note:: We recommend Unmanaging Instance in Running state to preserve the exact domain XML. There is potential to loose some information when unmanaging in Stopped state.
+
+
 Unmanaging Instance actions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
+++ b/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
@@ -362,20 +362,21 @@ Preserving unmanaged Instance NICs
 The zone setting: unmanage.vm.preserve.nics can be used to preserve Instance NICs and its MAC addresses after unmanaging them. If set to true, the Instance NICs (and their MAC addresses) are preserved when unmanaging it. Otherwise, NICs are removed and MAC addresses can be reassigned.
 
 
-KVM Specific: Persistent Domain XML when unmanaging Instances
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Persistent KVM Domain XML for Unmanaged Instances
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Since 4.22, domain XML will be made persistent when Instance is unmanaged from CloudStack. This will allow to manage the Instance outside of CloudStack using virsh or other libvirt tools. The domain XML will be stored in directory /etc/libvirt/qemu.
+Since 4.22, the domain XML of an Instance is made persistent when it is unmanaged from CloudStack. This allows the Instance to be managed directly outside of CloudStack using `virsh` or other libvirt tools. The domain XML will be stored in the directory `/etc/libvirt/qemu` on the relevant KVM host.
 
 Domain XML is taken from Instance but varies based on their state:
 
 - Running Instance
-   - Domain XML is contructed from the Instance and persisted on the Host where the Instance is running
+   - The existing domain XML is retrieved from the Instance and persisted on the host where the Instance is running.
 - Stopped Instance
-   - Domain XML is constructed from the Instance details available in CloudStack database
-   - Domain XML will pe persisted on the last host where the Instance was running before stopping it
+   - The domain XML is reconstructed from the Instance details available in the CloudStack database.
+   - The reconstructed domain XML is persisted on the last host where the Instance was running before is was stopped.
 
-.. note:: We recommend Unmanaging Instance in Running state to preserve the exact domain XML. There is potential to loose some information when unmanaging in Stopped state.
+.. note:: 
+   It is recommended to unmanage Instances while they are in the **Running** state to ensure that the exact domain XML is preserved. When unmanaged in the **Stopped** state, some information may be lost due to reconstruction.
 
 
 Unmanaging Instance actions

--- a/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
+++ b/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
@@ -373,7 +373,7 @@ Domain XML is taken from Instance but varies based on their state:
    - The existing domain XML is retrieved from the Instance and persisted on the host where the Instance is running.
 - Stopped Instance
    - The domain XML is reconstructed from the Instance details available in the CloudStack database.
-   - The reconstructed domain XML is persisted on the last host where the Instance was running before it was stopped. If the host is no longer available, the domain XML is persisted on any other host available in the Zone.
+   - The reconstructed domain XML is persisted on the last host where the Instance was running before it was stopped. If that host is no longer available, the domain XML is saved on any other available host within the cluster.
 
 .. note:: 
    It is recommended to unmanage Instances while they are in the **Running** state to ensure that the exact domain XML is preserved. When unmanaged in the **Stopped** state, some information may be lost due to reconstruction.

--- a/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
+++ b/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
@@ -339,7 +339,19 @@ Unmanaging Instances
 
 Administrators can unmanage guest Instances from CloudStack. Once unmanaged, CloudStack can no longer monitor, control or administer the provisioning and orchestration-related operations on an Instance.
 
-To unmanage a guest Instance, an administrator must either use the UI or invoke the unmanageVirtualMachine API passing the ID of the Instance to unmanage. The API has the following preconditions:
+To unmanage a guest Instance, an administrator must either use the UI or invoke the unmanageVirtualMachine API passing the ID of the Instance to unmanage. 
+
+.. code:: bash
+
+   cmk unmanage virtualmachine id=<instance-id>
+
+The API supports the `hostid` parameter for stopped instances on the KVM hypervisor, allowing the domain XML to be persisted on the specified host.
+
+.. code:: bash
+
+   cmk unmanage virtualmachine id=<instance-id> hostid=<host-id>
+
+The API has the following preconditions:
 
 - The Instance must not be destroyed
 - The Instance state must be 'Running’ or ‘Stopped’

--- a/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
+++ b/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
@@ -373,7 +373,7 @@ Domain XML is taken from Instance but varies based on their state:
    - The existing domain XML is retrieved from the Instance and persisted on the host where the Instance is running.
 - Stopped Instance
    - The domain XML is reconstructed from the Instance details available in the CloudStack database.
-   - The reconstructed domain XML is persisted on the last host where the Instance was running before is was stopped.
+   - The reconstructed domain XML is persisted on the last host where the Instance was running before it was stopped. If the host is no longer available, the domain XML is persisted on any other host available in the Zone.
 
 .. note:: 
    It is recommended to unmanage Instances while they are in the **Running** state to ensure that the exact domain XML is preserved. When unmanaged in the **Stopped** state, some information may be lost due to reconstruction.

--- a/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
+++ b/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
@@ -455,6 +455,8 @@ Prerequisites
 - Currently, it's supported to only use NFS and Local storage as the destination Primary Storage pools in CloudStack
 - Currently, only libvirt-based instances can be migrated
 
+.. note:: Allocate a NIC to any instance without one immediately after importing it into CloudStack.
+
 listVmsForImport API
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR is to add documentation for https://github.com/apache/cloudstack/pull/11541. 

Dev PR is bringing following changes:

1. KVM domain will be persistent when Instance gets unmanaged from CloudStack.
2. Support Unmanaging Stopped Instance and persisting domainXML

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--562.org.readthedocs.build/en/562/

<!-- readthedocs-preview cloudstack-documentation end -->