### PR TITLE
adding nmcli commands to configure Oracle Linux host

### DIFF
--- a/source/installguide/hypervisor/kvm.rst
+++ b/source/installguide/hypervisor/kvm.rst
@@ -861,6 +861,38 @@ although a reboot is recommended to see if everything works properly.
    in case you made a configuration error and the network stops functioning!
 
 
+Configure Oracle Linux for Basic Networks using nmcli
+'''''''''''''''''''''''''''''''''''''''''''''''''''''
+All the required packages were installed when you installed libvirt, so
+we only have to configure the network.
+
+Disable IP settings on physical NIC first
+
+.. parsed-literal::
+   nmcli con mod eth0 ipv4.method disabled ipv6.method ignore
+  
+Configure cloudbr0 and include the Management IP of the hypervisor.
+
+.. parsed-literal::
+   nmcli con add type bridge ifname cloudbr0 con-name cloudbr0
+   nmcli con add type ethernet ifname eth0 master cloudbr0 slave-type bridge con-name cloudbr0-eth0
+   nmcli con modify cloudbr0 ipv4.addresses  192.168.42.11/24 ipv4.gateway 192.168.42.1 ipv4.method manual ipv6.method ignore
+
+
+Configure cloudbr1 as a plain bridge without an IP address
+
+.. parsed-literal::
+   nmcli con add type bridge ifname cloudbr1 con-name cloudbr1 ipv4.method disabled  ipv6.method ignore
+   nmcli con add type vlan ifname eth0.20 dev eth0 id 20 master cloudbr1 con-name vlan20
+
+With this configuration you should be able to restart the network,
+although a reboot is recommended to see if everything works properly.
+
+.. warning::
+   Make sure you have an alternative way like IPMI or ILO to reach the machine
+   in case you made a configuration error and the network stops functioning!
+
+
 
 Network Example for Advanced Networks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1165,6 +1197,38 @@ although a reboot is recommended to see if everything works properly.
 .. warning::
    Make sure you have an alternative way like IPMI or ILO to reach the machine
    in case you made a configuration error and the network stops functioning!
+
+
+Configure Oracle Linux for Advance Networks using nmcli
+'''''''''''''''''''''''''''''''''''''''''''''''''''''
+All the required packages were installed when you installed libvirt, so
+we only have to configure the network.
+
+Disable IP settings on physical NICs first
+
+.. parsed-literal::
+   nmcli con mod eth0 ipv4.method disabled ipv6.method ignore
+   nmcli con mod eth1 ipv4.method disabled ipv6.method ignore
+  
+Configure cloudbr0 and include the Management IP of the hypervisor.
+
+.. parsed-literal::
+   nmcli con add type bridge ifname cloudbr0 con-name cloudbr0 ipv4.addresses 192.168.42.11/24 ipv4.gateway 192.168.42.1 ipv4.method manual ipv6.method ignore
+   nmcli con add type ethernet ifname eth0 master cloudbr0 slave-type bridge con-name cloudbr0-eth0
+
+Configure cloudbr1 as a plain bridge without an IP address
+
+.. parsed-literal::
+   nmcli con add type bridge ifname cloudbr1 con-name cloudbr1 ipv4.method disabled ipv6.method ignore
+   nmcli con add type ethernet ifname eth1 master cloudbr1 slave-type bridge con-name cloudbr1-eth1
+
+With this configuration you should be able to restart the network,
+although a reboot is recommended to see if everything works properly.
+
+.. warning::
+   Make sure you have an alternative way like IPMI or ILO to reach the machine
+   in case you made a configuration error and the network stops functioning!
+
 
 
 Configure the network using OpenVswitch


### PR DESCRIPTION
Add initial nmcli examples for KVM host setup, including Oracle Linux. Current docs lack references to NetworkManager usage, and with most Linux distros moving to NetworkManager by default, these commands provide a starting point for users.

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--570.org.readthedocs.build/en/570/

<!-- readthedocs-preview cloudstack-documentation end -->