### PR TITLE
Document KVM VM metadata handling in unmanage process

### DIFF
--- a/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
+++ b/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
@@ -361,7 +361,7 @@ The API has the following preconditions:
 - The Instance must be a VMware Instance (as of CloudStack 4.19, it's also possible to unmanage a KVM-based Instances)
 
 .. warning::
-   Starting with the 4.22.0 release, when a KVM VM is unmanaged, its infrastructure metadata (zone, pod, cluster, and host) in the libvirt VM XML is preserved.
+   Starting with the 4.22.1 release, when a KVM instance is unmanaged, the infrastructure metadata (zone, pod, cluster, and host details) is preserved in the libvirt VM XML.
    This information is left for the user’s discretion—allowing them to either retain it or remove it manually or through scripts.
 
 The API execution will perform the following pre-checks, failing if they are not met:

--- a/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
+++ b/source/adminguide/virtual_machines/importing_unmanaging_vms.rst
@@ -360,6 +360,10 @@ The API has the following preconditions:
 - The Instance state must be 'Running’ or ‘Stopped’
 - The Instance must be a VMware Instance (as of CloudStack 4.19, it's also possible to unmanage a KVM-based Instances)
 
+.. warning::
+   Starting with the 4.22.0 release, when a KVM VM is unmanaged, its infrastructure metadata (zone, pod, cluster, and host) in the libvirt VM XML is preserved.
+   This information is left for the user’s discretion—allowing them to either retain it or remove it manually or through scripts.
+
 The API execution will perform the following pre-checks, failing if they are not met:
 
 - There are no Volume Snapshots associated with any of the Instance volumes


### PR DESCRIPTION
Added a warning about KVM VM metadata preservation when unmanaged.

From the enhancement PR https://github.com/apache/cloudstack/pull/11061, as per discussion concluded to explicitly call out the VM behavior for unmanaged KVM VMs regarding the retention of libvirt metadata.

This PR adds a note to the documentation warning users that CloudStack does not cleanup the libvirt metadata for unamanged VMs, leaving it for user's choice.

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--595.org.readthedocs.build/en/595/

<!-- readthedocs-preview cloudstack-documentation end -->