### PR TITLE
Update python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-docutils==0.20.1
-Sphinx==7.2.6
-sphinx-rtd-theme==2.0.0
+docutils==0.21.2
+Sphinx==8.2.3
+sphinx-rtd-theme==3.0.2
 readthedocs-sphinx-ext==2.2.5
-Jinja2==3.1.5
+Jinja2==3.1.6

--- a/source/conf.py
+++ b/source/conf.py
@@ -41,9 +41,6 @@ rst_epilog = """
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.autosectionlabel',
 ]
@@ -185,11 +182,6 @@ epub_exclude_files = ['search.html']
 
 
 # -- Extension configuration -------------------------------------------------
-
-# -- Options for intersphinx extension ---------------------------------------
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
 
 # -- Options for todo extension ----------------------------------------------
 


### PR DESCRIPTION
This pull request simplifies the Sphinx documentation configuration by removing some unused extensions and their related settings. The focus is on streamlining the documentation build process.

Removed Sphinx extensions and related configuration:

* Removed the `sphinx.ext.autodoc`, `sphinx.ext.doctest`, and `sphinx.ext.intersphinx` extensions from the `extensions` list in `source/conf.py`.
* Deleted the `intersphinx_mapping` configuration, since the `sphinx.ext.intersphinx` extension is no longer used.