### PR TITLE
add post upgrade procedures

### DIFF
--- a/source/upgrading/upgrade/_post_upgrade.rst
+++ b/source/upgrading/upgrade/_post_upgrade.rst
@@ -1,0 +1,45 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information#
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+.. sub-section included in upgrade notes.
+
+Post Upgrade Procedures
+------------------------
+
+After upgrading CloudStack packages, new system properties and settings may be 
+introduced in the release. CloudStack will not overwrite or replace your existing
+configuration files. The latest configuration file are named with .rpmnew or .dpkg-dist 
+extention depends on your package manager. 
+
+It is strongly recommended to review and apply these new changes manually by comparing 
+them to your previously installed version.
+
+
+The locations of the essential configuration properties files are as follows:
+
+.. parsed-literal::
+
+   /etc/default/cloudstack-management
+   /etc/default/cloudstack-usage
+   /etc/cloudstack/management/db.properties
+   /etc/cloudstack/management/config.json
+   /etc/cloudstack/management/server.properties
+   /etc/cloudstack/management/environment.properties
+   /etc/cloudstack/management/java.security.ciphers
+
+
+
+
+

--- a/source/upgrading/upgrade/upgrade-4.20.rst
+++ b/source/upgrading/upgrade/upgrade-4.20.rst
@@ -209,6 +209,8 @@ Setup the GPG public key if you wish to enable ``gpgcheck=1``:
 
 .. include:: _log4j_file_check.rst
 
+.. include:: _post_upgrade.rst
+
 .. _upg_hyp_414:
 
 Upgrade Hypervisors

--- a/source/upgrading/upgrade/upgrade-4.21.rst
+++ b/source/upgrading/upgrade/upgrade-4.21.rst
@@ -209,6 +209,8 @@ Setup the GPG public key if you wish to enable ``gpgcheck=1``:
 
 .. include:: _log4j_file_check.rst
 
+.. include:: _post_upgrade.rst
+
 .. _upg_hyp_414:
 
 Upgrade Hypervisors

--- a/source/upgrading/upgrade/upgrade-4.22.rst
+++ b/source/upgrading/upgrade/upgrade-4.22.rst
@@ -218,6 +218,8 @@ Setup the GPG public key if you wish to enable ``gpgcheck=1``:
 
 .. include:: _log4j_file_check.rst
 
+.. include:: _post_upgrade.rst
+
 .. _upg_hyp_414:
 
 Upgrade Hypervisors


### PR DESCRIPTION
This pull request proposes an enhancement to the CloudStack package upgrade procedures, specifically addressing the reliability concerns arising from the manual configuration updates required for updates after version 4.20.


<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--614.org.readthedocs.build/en/614/

<!-- readthedocs-preview cloudstack-documentation end -->