### PR TITLE
[Doc] ceph-common package requirement on KVM hosts, to get the physical size of the snapshots for the volumes on ceph primary storage

### DIFF
--- a/source/installguide/hypervisor/kvm.rst
+++ b/source/installguide/hypervisor/kvm.rst
@@ -1646,7 +1646,7 @@ switch.
 
 CloudStack uses rbd cmd to get the physical size of the snapshots for the volumes on ceph
 primary storage. This requires ceph-common package to be installed on the KVM hosts. If it
-is not installed, the allocated size is used for the physical size.
+is not installed, the allocated size is used for the physical size of the snapshots.
 
 Live Migration
 ^^^^^^^^^^^^^^

--- a/source/installguide/hypervisor/kvm.rst
+++ b/source/installguide/hypervisor/kvm.rst
@@ -1644,6 +1644,9 @@ In order to be able to perform Volume Snapshots on CentOS 6.x (greater than 6.4)
 replace your version of qemu-img with one which has been patched to include the '-s'
 switch.
 
+CloudStack uses rbd cmd to get the physical size of the snapshots for the volumes on ceph
+primary storage. This requires ceph-common package to be installed on the KVM hosts. If it
+is not installed, the allocated size is used for the physical size.
 
 Live Migration
 ^^^^^^^^^^^^^^

--- a/source/installguide/hypervisor/kvm.rst
+++ b/source/installguide/hypervisor/kvm.rst
@@ -1644,9 +1644,9 @@ In order to be able to perform Volume Snapshots on CentOS 6.x (greater than 6.4)
 replace your version of qemu-img with one which has been patched to include the '-s'
 switch.
 
-CloudStack uses rbd cmd to get the physical size of the snapshots for the volumes on ceph
+CloudStack uses the rbd command to get the physical size of the snapshots for the volumes on ceph
 primary storage. This requires ceph-common package to be installed on the KVM hosts. If it
-is not installed, the allocated size is used for the physical size of the snapshots.
+is not installed, the allocated size is used as the physical size of the snapshots.
 
 Live Migration
 ^^^^^^^^^^^^^^


### PR DESCRIPTION


<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--622.org.readthedocs.build/en/622/

<!-- readthedocs-preview cloudstack-documentation end -->