### PR TITLE
Update settings for SELinux and Apparmor

### DIFF
--- a/source/developersguide/ansible.rst
+++ b/source/developersguide/ansible.rst
@@ -272,16 +272,6 @@ For the management server role we create a main.yml task like this:
      template: src=cloudstack.repo.j2 dest=/etc/yum.repos.d/cloudstack.repo
 
 
-   - name: Ensure selinux is in permissive mode
-
-     command: setenforce permissive
-
-
-   - name: Ensure selinux is set permanently
-
-     selinux: policy=targeted state=permissive
-
-
    -name: Ensure CloudStack packages are installed
 
      yum: name=cloud-client state=present

--- a/source/installguide/hypervisor/kvm.rst
+++ b/source/installguide/hypervisor/kvm.rst
@@ -547,7 +547,7 @@ CloudStack does various things which can be blocked by security
 mechanisms like AppArmor and SELinux. These have to be disabled to
 ensure the Agent has all the required permissions.
 
-#. Configure SELinux (RHEL, CentOS, SUSE)
+#. Configure SELinux (RHEL, CentOS)
 
    #. Check to see whether SELinux is installed on your machine. If not,
       you can skip this section.
@@ -560,39 +560,27 @@ ensure the Agent has all the required permissions.
          $ rpm -qa | grep selinux
 
    #. Set the SELINUX variable in ``/etc/selinux/config`` to
-      "permissive". This ensures that the permissive setting will be
+      "enforcing" or "permissive". This ensures that the setting will be
       maintained after a system reboot.
 
-      In RHEL or CentOS:
-
-      .. parsed-literal::
-
-         $ vi /etc/selinux/config
-
-      Change the following line
-
-      .. parsed-literal::
-
-         SELINUX=enforcing
-
-      to this
-
-      .. parsed-literal::
-
-         SELINUX=permissive
-
-   #. Then set SELinux to permissive starting immediately, without
+   #. Then set SELinux to enforcing or permissive starting immediately, without
       requiring a system reboot.
 
       .. parsed-literal::
 
-         $ setenforce permissive
+         $ setenforce enforcing
+
+   #. Set the security driver in ``/etc/libvirt/qemu.conf`` to "none".
+
+      .. parsed-literal::
+
+         security_driver="none"
 
 .. note:: In a production environment, selinux should be set to enforcing
    and the necessary selinux policies are created to allow the
    services to run.
 
-#. Configure Apparmor (Ubuntu)
+#. Configure Apparmor (Ubuntu, SUSE)
 
 
    #. Check to see whether AppArmor is installed on your machine. If
@@ -605,23 +593,23 @@ ensure the Agent has all the required permissions.
 
          $ dpkg --list 'apparmor'
 
-   #. Disable the AppArmor profiles for libvirt
+      In Ubuntu, install package apparmor-utils if not present.     
 
       .. parsed-literal::
 
-         $ ln -s /etc/apparmor.d/usr.sbin.libvirtd /etc/apparmor.d/disable/
+         $ apt install apparmor-utils
+
+   #. Then set Apparmor to enforcing mode
 
       .. parsed-literal::
 
-         $ ln -s /etc/apparmor.d/usr.lib.libvirt.virt-aa-helper /etc/apparmor.d/disable/
+         $ aa-enforce /etc/apparmor.d/*
+
+   #. Set the security driver in ``/etc/libvirt/qemu.conf`` to "none".
 
       .. parsed-literal::
 
-         $ apparmor_parser -R /etc/apparmor.d/usr.sbin.libvirtd
-
-      .. parsed-literal::
-
-         $ apparmor_parser -R /etc/apparmor.d/usr.lib.libvirt.virt-aa-helper
+         security_driver="none"
 
 
 Configuring the Networking

--- a/source/installguide/management-server/_database.rst
+++ b/source/installguide/management-server/_database.rst
@@ -138,33 +138,15 @@ MySQL. See :ref:`install-database-on-separate-node`.
          rpm -qa | grep selinux
 
    #. Set the SELINUX variable in ``/etc/selinux/config`` to
-      "permissive". This ensures that the permissive setting will be
+      "enforcing" or "permissive". This ensures that the setting will be
       maintained after a system reboot.
 
-      In RHEL or CentOS:
-
-      .. parsed-literal::
-
-         vi /etc/selinux/config
-
-      Change the following line
-
-      .. parsed-literal::
-
-         SELINUX=enforcing
-
-      to this:
-
-      .. parsed-literal::
-
-         SELINUX=permissive
-
-   #. Set SELinux to permissive starting immediately, without requiring
+   #. Set SELinux to enforcing or permissive starting immediately, without requiring
       a system reboot.
 
       .. parsed-literal::
 
-         setenforce permissive
+         setenforce enforcing
 
 .. note:: In a production environment, selinux should be set to enforcing
    and the necessary selinux policies are created to allow the

--- a/source/quickinstallationguide/qig.rst
+++ b/source/quickinstallationguide/qig.rst
@@ -192,19 +192,17 @@ SELinux
 ^^^^^^^
 
 In an ideal environment, selinux should be set to enforcing and the necessary
-selinux policies are created to allow the services to run. For this guide,
-we will set selinux to permissive mode. This will allow us to install and
-configure the services without having to worry about selinux policies.
+selinux policies are created to allow the services to run.
 
-To configure SELinux to be permissive in the running system we need to run the 
+To configure SELinux to be enforcing in the running system we need to run the 
 following command:
 
 .. parsed-literal::
 
-   # setenforce 0
+   # setenforce 1
 
 To ensure that it remains in that state we need to configure the file 
-/etc/selinux/config to reflect the permissive state, as shown in this example:
+/etc/selinux/config to reflect the enforcing state, as shown in this example:
 
 .. parsed-literal::
 
@@ -213,7 +211,7 @@ To ensure that it remains in that state we need to configure the file
    # enforcing - SELinux security policy is enforced.
    # permissive - SELinux prints warnings instead of enforcing.
    # disabled - No SELinux policy is loaded.
-   SELINUX=permissive
+   SELINUX=enforcing
    # SELINUXTYPE= can take one of these two values:
    # targeted - Targeted processes are protected,
    # mls - Multi Level Security protection.


### PR DESCRIPTION
Doc for apache/cloudstack#13281

- Enable SELinux enforcing mode on RHEL/CentOS
- Enable Apparmor enforcing mode on Ubuntu/Debian/SUSE
- Set "security_driver" to "none" in qemu.conf on KVM host

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--662.org.readthedocs.build/en/662/

<!-- readthedocs-preview cloudstack-documentation end -->