### PR TITLE
Add information on backup and restore timeouts

### DIFF
--- a/source/adminguide/backup_and_recovery.rst
+++ b/source/adminguide/backup_and_recovery.rst
@@ -317,3 +317,27 @@ the backup size, although the actual backup size may be less than the size use t
    :alt: Select Zone when creating Instance from Backup
    :width: 700px
 
+Configuring Backup and Restore Timeouts
+---------------------------------------
+
+The default timeout for backup and restore commands is 3600 seconds (1 hour). 
+For large Instances or slower backup repositories, backup and restore operations may take longer than this timeout.
+
+The timeout for individual commands can be configured using the `commands.timeout` global setting. 
+This setting accepts comma-separated key-value pairs, where the key is the command name and the value is the timeout in seconds.
+
+For example, to configure a timeout of two hours for both backup and restore operations, add:
+
+`TakeBackupCommand=7200,RestoreBackupCommand=7200`
+
+The Management Server must be restarted after changing the `commands.timeout` setting.
+
+The configured timeout can be verified in the Management Server log. For example:
+
+`Wait time setting on org.apache.cloudstack.backup.TakeBackupCommand is 7200 seconds`
+
+.. note::
+The command timeout determines how long the Management Server waits for the operation to complete. 
+Timing out the command does not necessarily terminate the underlying backup or restore operation on the hypervisor. 
+For example, with the NAS Backup & Recovery plugin on KVM, the corresponding libvirt operation may continue after the command times out on the Management Server.
+

--- a/source/adminguide/backup_and_recovery.rst
+++ b/source/adminguide/backup_and_recovery.rst
@@ -339,5 +339,6 @@ The configured timeout can be verified in the Management Server log. For example
 .. note::
 The command timeout determines how long the Management Server waits for the operation to complete. 
 Timing out the command does not necessarily terminate the underlying backup or restore operation on the hypervisor. 
-For example, with the NAS Backup & Recovery plugin on KVM, the corresponding libvirt operation may continue after the command times out on the Management Server.
+For example, with the NAS Backup & Recovery plugin on KVM, the corresponding libvirt operation may continue after the command times out on the Management Server. 
+The finished backup will not be tracked by CloudStack in this case and as such won't be cleaned up by a configured rotation.
 


### PR DESCRIPTION
Based on https://github.com/apache/cloudstack/issues/13883

This PR is to add information on timeouts for backup jobs.

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--675.org.readthedocs.build/en/675/

<!-- readthedocs-preview cloudstack-documentation end -->