### PR TITLE
Update note on CLVM support for KVM

### DIFF
--- a/source/conceptsandterminology/storage_setup.rst
+++ b/source/conceptsandterminology/storage_setup.rst
@@ -34,9 +34,6 @@ Fiber Channel  Supported via Pre-existing SR   Supported           Supported via
 Local Disk     Supported                       Supported           Supported
 =============  ==============================  ==================  ===================================
 
-The use of the Cluster Logical Volume Manager (CLVM) for KVM is not officially supported with
-CloudStack.
-
 .. _about-secondary-storage:
 
 Secondary Storage


### PR DESCRIPTION
Remove historic note about clvm support with KVM.

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--680.org.readthedocs.build/en/680/

<!-- readthedocs-preview cloudstack-documentation end -->